### PR TITLE
[RFC] Add Generator for Handling Final Piece of RAG

### DIFF
--- a/examples/localFileIngestion.ts
+++ b/examples/localFileIngestion.ts
@@ -5,6 +5,7 @@ import { PineconeVectorDB } from "../src/data-store/vector-DBs/pineconeVectorDB"
 import { InMemoryDocumentMetadataDB } from "../src/document/metadata/InMemoryDocumentMetadataDB";
 import { FileSystem } from "../src/ingestion/data-sources/dataSource";
 import * as SimpleDocumentParser from "../src/ingestion/document-parsers/simpleDocumentParser";
+import { OpenAICompletionGenerator } from "../src/generator/llm/openAICompletionGenerator";
 import { VectorDBDocumentRetriever } from "../src/retrieval/vectorDBDocumentRetriever";
 
 const metadataDB = new InMemoryDocumentMetadataDB();
@@ -27,9 +28,11 @@ async function main() {
   const vectorDB = await createIndex();
   const accessPassport = new AccessPassport();
   const retriever = new VectorDBDocumentRetriever(vectorDB);
-  const res = await retriever.retrieveData({
+  const generator = new OpenAICompletionGenerator();
+  const res = await generator.run({
     accessPassport,
-    query: "How do I use parameters in a workbook?",
+    prompt: "How do I use parameters in a workbook?",
+    retriever,
   });
   console.log(res);
 }

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -1,0 +1,17 @@
+import { AccessPassport } from "../access-control/accessPassport";
+import { JSONValue } from "../common/jsonTypes";
+import { BaseRetriever } from "../retrieval/retriever";
+
+export type GeneratorParams<D> = {
+  prompt: JSONValue;
+  accessPassport?: AccessPassport;
+  retriever?: BaseRetriever<D>;
+};
+
+/**
+ * Generators are used for generating some response based on a prompt and
+ * retrieved data (if applicable).
+ */
+export abstract class BaseGenerator<D, G> {
+  protected abstract run(params: GeneratorParams<D>): Promise<G>;
+}

--- a/src/generator/llm/openAICompletionGenerator.ts
+++ b/src/generator/llm/openAICompletionGenerator.ts
@@ -1,0 +1,20 @@
+import { JSONObject } from "../../common/jsonTypes";
+import { GeneratorParams } from "../generator";
+import { Document } from "../../document/document";
+import { TextGenerator } from "../textGenerator";
+
+export type OpenAICompletionGeneratorParams = GeneratorParams<Document[]> & {
+  completionParams?: JSONObject; // TODO: Add openai API completion params type
+};
+
+// TODO: Implement this for different openai completion models
+export class OpenAICompletionGenerator extends TextGenerator {
+  constructor() {
+    super();
+    // TODO: Initialize OpenAI API client
+  }
+
+  run(_params: OpenAICompletionGeneratorParams): Promise<string> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/generator/textGenerator.ts
+++ b/src/generator/textGenerator.ts
@@ -1,0 +1,9 @@
+import { GeneratorParams } from "./generator";
+import { Document } from "../document/document";
+
+/**
+ * Simple abstract class for generating text from a prompt and retrieved Documents.
+ */
+export abstract class TextGenerator {
+  protected abstract run(params: GeneratorParams<Document[]>): Promise<string>;
+}


### PR DESCRIPTION
[RFC] Add Generator for Handling Final Piece of RAG

The final piece of RAG ('generation') should also be handled in our semantic retrieval library. Ideally, we want to support some non-trivial generations, including using prompt templates and for completion and performing response synthesis and validation.

To do so, this PR adds a generator base class with `run` method. Custom classes can implement their own logic for what 'generation' means

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/5).
* #7
* #6
* __->__ #5