### PR TITLE
[LAS-429][3/n] Callbacks for BaseDocumentTransformer & TextChunkTransformer

### DIFF
--- a/__tests__/utils/callbacks.test.ts
+++ b/__tests__/utils/callbacks.test.ts
@@ -10,8 +10,8 @@ import {
 import type { RawDocument } from "../../src/document/document";
 
 import { DirectDocumentParser } from "../../src/ingestion/document-parsers/directDocumentParser";
-import { TextDocumentParser } from "../../src/ingestion/document-parsers/textDocumentParser";
 import { getTestRawDocument } from "./testDocumentUtils";
+import { SeparatorTextChunker } from "../../src/transformation/document/text/separatorTextChunker";
 
 describe("Callbacks", () => {
   test("Callback arg static type", async () => {
@@ -113,5 +113,31 @@ describe("Callbacks", () => {
     expect(onParseSuccessCallback1).toHaveBeenCalled();
 
     expect(onParseErrorCallback1).not.toHaveBeenCalled();
+  });
+
+  test("Document Transformer", async () => {
+    const onTransformDocumentsCallbacks = [jest.fn(), jest.fn()];
+    const onTransformDocumentCallback1 = jest.fn();
+    const onChunkTextCallback1 = jest.fn();
+
+    const callbacks: CallbackMapping = {
+      onTransformDocuments: onTransformDocumentsCallbacks,
+      onTransformDocument: [onTransformDocumentCallback1],
+      onChunkText: [onChunkTextCallback1],
+    };
+    const callbackManager = new CallbackManager("rag-run-0", callbacks);
+    const documentParser = new DirectDocumentParser();
+
+    const documentChunker = new SeparatorTextChunker({ callbackManager });
+
+    try {
+      const document = await documentParser.parse(getTestRawDocument());
+      await documentChunker.transformDocuments([document]);
+    } catch (error) {}
+
+    expect(onTransformDocumentCallback1).toHaveBeenCalled();
+    expect(onChunkTextCallback1).toHaveBeenCalled();
+
+    expect(onTransformDocumentsCallbacks[0]).toHaveBeenCalled();
   });
 });

--- a/src/transformation/document/documentTransformer.ts
+++ b/src/transformation/document/documentTransformer.ts
@@ -1,5 +1,10 @@
 import { Document } from "../../document/document";
 import { DocumentMetadataDB } from "../../document/metadata/documentMetadataDB";
+import {
+  CallbackManager,
+  Traceable,
+  TranformDocumentsEvent,
+} from "../../utils/callbacks";
 import { Transformer } from "../transformer";
 
 /**
@@ -7,22 +12,37 @@ import { Transformer } from "../transformer";
  * one or more new documents. Common transformations include text
  * chunking and summarization.
  */
-export interface DocumentTransformer
-  extends Transformer<Document[]> {}
+export interface DocumentTransformer extends Transformer<Document[]> {}
 
-export abstract class BaseDocumentTransformer implements DocumentTransformer {
+export abstract class BaseDocumentTransformer
+  implements DocumentTransformer, Traceable
+{
   documentMetadataDB?: DocumentMetadataDB;
+  callbackManager?: CallbackManager;
 
-  constructor(documentMetadataDB?: DocumentMetadataDB) {
+  constructor(
+    documentMetadataDB?: DocumentMetadataDB,
+    callbackManager?: CallbackManager
+  ) {
     this.documentMetadataDB = documentMetadataDB;
+    this.callbackManager = callbackManager;
   }
-  
+
   abstract transformDocument(document: Document): Promise<Document>;
 
   async transformDocuments(documents: Document[]): Promise<Document[]> {
     const transformPromises = documents.map((document) =>
       this.transformDocument(document)
     );
-    return (await Promise.all(transformPromises)).flat();
+    const transformedDocuments = (await Promise.all(transformPromises)).flat();
+
+    const event: TranformDocumentsEvent = {
+      name: "onTransformDocuments",
+      transformedDocuments,
+      originalDocuments: documents,
+    };
+    this.callbackManager?.runCallbacks(event);
+
+    return transformedDocuments;
   }
 }

--- a/src/transformation/document/text/separatorTextChunker.ts
+++ b/src/transformation/document/text/separatorTextChunker.ts
@@ -1,3 +1,4 @@
+import { ChunkTextEvent } from "../../../utils/callbacks";
 import {
   TextChunkConfig,
   TextChunkTransformer,
@@ -23,8 +24,16 @@ export class SeparatorTextChunker extends TextChunkTransformer {
     this.separator = params?.separator ?? this.separator;
   }
 
-  chunkText(text: string): Promise<string[]> {
+  async chunkText(text: string): Promise<string[]> {
     const subChunks = this.subChunkOnSeparator(text, this.separator);
-    return this.mergeSubChunks(subChunks, this.separator);
+    const mergedChunks = await this.mergeSubChunks(subChunks, this.separator);
+    
+    const event: ChunkTextEvent = {
+      name: "onChunkText",
+      chunks: mergedChunks,
+    };
+    this.callbackManager?.runCallbacks(event);
+
+    return mergedChunks;
   }
 }

--- a/src/utils/callbacks.ts
+++ b/src/utils/callbacks.ts
@@ -1,4 +1,9 @@
-import type { IngestedDocument, RawDocument } from "../document/document";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type {
+  IngestedDocument,
+  RawDocument,
+  Document,
+} from "../document/document";
 
 export type LoadDocumentsSuccessEvent = {
   name: "onLoadDocumentsSuccess";
@@ -36,6 +41,23 @@ export type ParseSuccessEvent = {
   ingestedDocument: IngestedDocument;
 };
 
+export type TranformDocumentsEvent = {
+  name: "onTransformDocuments";
+  transformedDocuments: Document[];
+  originalDocuments: Document[];
+};
+
+export type TransformDocumentEvent = {
+  name: "onTransformDocument";
+  originalDocument: Document;
+  transformedDocument: Document;
+};
+
+export type ChunkTextEvent = {
+  name: "onChunkText";
+  chunks: string[];
+};
+
 type CallbackEvent =
   | LoadDocumentsSuccessEvent
   | LoadDocumentsErrorEvent
@@ -43,7 +65,10 @@ type CallbackEvent =
   | DataSourceTestConnectionErrorEvent
   | ParseNextErrorEvent
   | ParseErrorEvent
-  | ParseSuccessEvent;
+  | ParseSuccessEvent
+  | TranformDocumentsEvent
+  | TransformDocumentEvent
+  | ChunkTextEvent;
 
 type Callback<T extends CallbackEvent> = (
   event: T,
@@ -58,6 +83,9 @@ interface CallbackMapping {
   onParseNextError?: Callback<ParseNextErrorEvent>[];
   onParseError?: Callback<ParseErrorEvent>[];
   onParseSuccess?: Callback<ParseSuccessEvent>[];
+  onTransformDocuments?: Callback<TranformDocumentsEvent>[];
+  onTransformDocument?: Callback<TransformDocumentEvent>[];
+  onChunkText?: Callback<ChunkTextEvent>[];
 }
 
 const DEFAULT_CALLBACKS: CallbackMapping = {
@@ -116,6 +144,24 @@ class CallbackManager {
           event,
           this.callbacks.onParseSuccess,
           DEFAULT_CALLBACKS.onParseSuccess
+        );
+      case "onTransformDocuments":
+        return await this.callback_helper(
+          event,
+          this.callbacks.onTransformDocuments,
+          DEFAULT_CALLBACKS.onTransformDocuments
+        );
+      case "onTransformDocument":
+        return await this.callback_helper(
+          event,
+          this.callbacks.onTransformDocument,
+          DEFAULT_CALLBACKS.onTransformDocument
+        );
+      case "onChunkText":
+        return await this.callback_helper(
+          event,
+          this.callbacks.onChunkText,
+          DEFAULT_CALLBACKS.onChunkText
         );
       default:
         assertUnreachable(event);


### PR DESCRIPTION
[LAS-429][3/n] Callbacks for BaseDocumentTransformer & TextChunkTransformer


Just run callbacks in implemented methods, didn't make base implementations in the base classes for abstract methods.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/34).
* #41
* #40
* #39
* #37
* __->__ #34