### PR TITLE
[LAS-430] evaluateDocumentListRetrieval + a few metrics

### DIFF
--- a/__tests__/evaluation/evaluation.test.ts
+++ b/__tests__/evaluation/evaluation.test.ts
@@ -1,0 +1,175 @@
+import TestVectorDB from "../__mocks__/retrieval/testVectorDB";
+
+import { InMemoryDocumentMetadataDB } from "../../src/document/metadata/inMemoryDocumentMetadataDB";
+import { VectorDBDocumentRetriever } from "../../src/retrieval/vector-DBs/vectorDBDocumentRetriever";
+import { TEST_VECTOR } from "../__mocks__/transformation/embeddings/testEmbeddings";
+import { VectorEmbedding } from "../../src/transformation/embeddings/embeddings";
+import {
+  VectorDBQuery,
+  VectorDBTextQuery,
+} from "../../src/data-store/vector-DBs/vectorDB";
+import { AccessPassport } from "../../src/access-control/accessPassport";
+
+import { getTestDocument } from "../__utils__/testDocumentUtils";
+/*  */
+// import from evaluation
+import {
+  evaluateRetrievers,
+  RetrievalEvaluationDataset,
+} from "../../src/evaluation/evaluation";
+
+import {
+  calculateRetrievedFragmentRecall,
+  calculateRetrievedFragmentPrecision,
+} from "../../src/evaluation/document";
+
+const mockQuery = jest.fn();
+
+jest.mock("../__mocks__/retrieval/testVectorDB", () =>
+  jest.fn().mockImplementation(() => ({
+    addDocuments: jest.fn(),
+    query: mockQuery,
+  }))
+);
+
+const retrievedEmbeddings: VectorEmbedding[] = [
+  {
+    vector: TEST_VECTOR,
+    text: "Test fragment 1 text",
+    metadata: {
+      source: "test-source-A",
+      stringArray: ["this", "is", "fine"],
+      num: 1,
+      bool: true,
+      documentId: "test-document-id-A",
+      fragmentId: "test-fragment-id-Aa",
+      nested: {
+        nestedString: "nested",
+        nestedNum: 2,
+        nestedBool: false,
+        nestedStringArray: ["all", "good"],
+        doubleNested: {
+          val: "test",
+        },
+      },
+      retrievalScore: 0.9,
+    },
+    attributes: {},
+  },
+  {
+    vector: TEST_VECTOR,
+    text: "Test fragment 2 text",
+    metadata: {
+      source: "test-source-A",
+      documentId: "test-document-id-A",
+      fragmentId: "test-fragment-id-Ab",
+      retrievalScore: 0.8,
+    },
+    attributes: {},
+  },
+  {
+    vector: TEST_VECTOR,
+    text: "Test fragment 3 text",
+    metadata: {
+      source: "test-source-B",
+      documentId: "test-document-id-B",
+      fragmentId: "test-fragment-id-Ba",
+      retrievalScore: 0.7,
+    },
+    attributes: {},
+  },
+  {
+    vector: TEST_VECTOR,
+    text: "Test fragment 4 text",
+    metadata: {
+      source: "test-source-C",
+      documentId: "test-document-id-C",
+      fragmentId: "test-fragment-id-Ca",
+      retrievalScore: 0.6,
+    },
+    attributes: {},
+  },
+];
+
+mockQuery.mockImplementation(async () => retrievedEmbeddings);
+
+const DOCUMENT_A_METADATA = {
+  documentId: "test-document-id-A",
+  uri: "test-uri-A",
+  document: getTestDocument({
+    documentId: "test-document-id-A",
+    fragments: [],
+  }),
+  metadata: {},
+  attributes: {},
+};
+
+const DOCUMENT_C_METADATA = {
+  documentId: "test-document-id-C",
+  document: getTestDocument({
+    documentId: "test-document-id-C",
+    fragments: [],
+  }),
+  uri: "test-uri-C",
+  metadata: {},
+  attributes: {},
+};
+
+describe("Retrieval evaluation metrics", () => {
+  test("Fragment-level precision and recall for VectorDBDocumentRetriever", async () => {
+    const metadataDB = new InMemoryDocumentMetadataDB({
+      "test-document-id-A": {
+        ...DOCUMENT_A_METADATA,
+        metadata: {
+          test: "test metadata for document A",
+        },
+      },
+      "test-document-id-C": {
+        ...DOCUMENT_C_METADATA,
+        metadata: {
+          test: "test metadata for document C",
+        },
+        attributes: { type: "webpage" },
+      },
+    });
+
+    const vectorDB = new TestVectorDB(metadataDB);
+    const retriever = new VectorDBDocumentRetriever({ vectorDB, metadataDB });
+
+    // fragments returned: Aa, Ab, Ba, Ca
+    const query: VectorDBTextQuery = {
+      text: "test",
+      topK: 5,
+    };
+
+    const queryParams = {
+      accessPassport: new AccessPassport(),
+      query,
+    };
+
+    const relevantFragmentIds: string[] = [
+      "test-fragment-id-Ab",
+      "test-fragment-id-Ca",
+      "test-fragment-id-Dc",
+      "test-fragment-id-Eb",
+      "test-fragment-id-Ec",
+    ];
+
+    const metrics = [
+      calculateRetrievedFragmentRecall,
+      calculateRetrievedFragmentPrecision,
+    ];
+
+    const evalDataset: RetrievalEvaluationDataset<string[], VectorDBQuery> = {
+      relevantDataByQuery: [[queryParams, relevantFragmentIds]],
+    };
+
+    const evalRes = await evaluateRetrievers([retriever], evalDataset, metrics);
+
+    const recall = evalRes[0]["documentFragmentRecall"];
+    const precision = evalRes[0]["documentFragmentPrecision"];
+
+    expect(recall).toBe(0.4);
+    expect(precision).toBe(0.5);
+  });
+});

--- a/src/evaluation/document.ts
+++ b/src/evaluation/document.ts
@@ -1,0 +1,48 @@
+import { Document } from "../document/document";
+
+import {
+  RetrievalMetric,
+  calculateRecall,
+  calculatePrecision,
+} from "./evaluation";
+
+function getRetrievedFragmentIds(retrievedDocuments: Document[]): Set<string> {
+  const retrievedFragmentIds = new Set<string>();
+  retrievedDocuments.forEach((document) => {
+    document.fragments.forEach((fragment) => {
+      retrievedFragmentIds.add(fragment.fragmentId);
+    });
+  });
+  return retrievedFragmentIds;
+}
+
+export const calculateRetrievedFragmentRecall: RetrievalMetric<
+  Document[],
+  string[]
+> = {
+  fn: (
+    retrievedDocuments: Document[],
+    relevantFragmentIds: string[]
+  ): number => {
+    const retrievedFragmentIds = getRetrievedFragmentIds(retrievedDocuments);
+    return calculateRecall(retrievedFragmentIds, new Set(relevantFragmentIds));
+  },
+  name: "documentFragmentRecall",
+};
+
+export const calculateRetrievedFragmentPrecision: RetrievalMetric<
+  Document[],
+  string[]
+> = {
+  fn: (
+    retrievedDocuments: Document[],
+    relevantFragmentIds: string[]
+  ): number => {
+    const retrievedFragmentIds = getRetrievedFragmentIds(retrievedDocuments);
+    return calculatePrecision(
+      retrievedFragmentIds,
+      new Set(relevantFragmentIds)
+    );
+  },
+  name: "documentFragmentPrecision",
+};

--- a/src/evaluation/evaluation.ts
+++ b/src/evaluation/evaluation.ts
@@ -1,0 +1,98 @@
+import {
+  BaseRetriever,
+  BaseRetrieverQueryParams,
+} from "../retrieval/retriever";
+
+// Interface
+
+// Types
+export interface RetrievalEvaluationDataset<E, Q> {
+  relevantDataByQuery: retrievalQueryExpectedResultPair<E, Q>[];
+}
+
+export interface RetrievalMetric<R, E> {
+  fn: (retrievedData: R, relevantData: E) => number;
+  name: string;
+}
+
+// Retrieval eval function
+/* 
+R: returned data type from retriever
+Q: query type
+E: expected data type
+
+Example: R = Document[], Q = VectorDBQuery, E = Fragment[]
+*/
+export async function evaluateRetrievers<R, Q, E>(
+  retrievers: BaseRetriever<R, Q>[],
+  data: RetrievalEvaluationDataset<E, Q>,
+  metrics: RetrievalMetric<R, E>[]
+) {
+  const results: { [metricName: string]: number }[] = [];
+
+  for (const retriever of retrievers) {
+    const record: { [metricName: string]: number } = {};
+    for (const metric of metrics) {
+      record[metric.name] = await averageMetricValue(retriever, metric, data);
+    }
+    results.push(record);
+  }
+
+  return results;
+}
+
+// Internal convenience types
+
+type retrievalQueryExpectedResultPair<E, Q> = [BaseRetrieverQueryParams<Q>, E];
+
+// Common metrics
+
+export function calculateRecall<T>(
+  retrievedIds: Set<T>,
+  relevantIds: Set<T>
+): number {
+  const intersection = setIntersect(retrievedIds, relevantIds);
+  return intersection.size / relevantIds.size;
+}
+
+export function calculatePrecision<T>(
+  retrievedIds: Set<T>,
+  relevantIds: Set<T>
+): number {
+  const intersection = setIntersect(retrievedIds, relevantIds);
+  return intersection.size / retrievedIds.size;
+}
+
+// Utility functions
+
+function setIntersect<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const intersection: Set<T> = new Set();
+  for (const elem of a) {
+    if (b.has(elem)) {
+      intersection.add(elem);
+    }
+  }
+  return intersection;
+}
+
+async function averageMetricValue<R, Q, E>(
+  retriever: BaseRetriever<R, Q>,
+  metric: RetrievalMetric<R, E>,
+  data: RetrievalEvaluationDataset<E, Q>
+): Promise<number> {
+  let total = 0;
+  const dataList: retrievalQueryExpectedResultPair<E, Q>[] =
+    data.relevantDataByQuery;
+  if (data.relevantDataByQuery.length === 0) {
+    throw new Error("No data in evaluation dataset");
+  }
+
+  for (let i = 0; i < dataList.length; i++) {
+    const qrp = dataList[i];
+    const [query, relevantData] = qrp;
+    const retrievedData = await retriever.retrieveData(query);
+
+    total += await metric.fn(retrievedData, relevantData);
+  }
+  return total / data.relevantDataByQuery.length;
+}


### PR DESCRIPTION
[LAS-430] evaluateDocumentListRetrieval + a few metrics

- Add interface (types + functions) for retrieval evaluation
- add precision + recall
- add document retrieval implementations (check fragment IDs against union across retrieved documents)

If necessary, we can extend this to work for ranking metrics (i.e. order-aware) like NDCG or MAP.
