### PR TITLE
Adding typescript compile step to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Lint
         run: |
           yarn lint
+      - name: Compile
+        run: |
+          yarn compile
       - name: Test
         run: |
           yarn test

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand",
+    "compile": "tsc",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/src/common/core.ts
+++ b/src/common/core.ts
@@ -1,4 +1,4 @@
 // Use this at the end of a switch to make it do static exhaustive checking.
-function assertUnreachable(_: never): never {
+export function assertUnreachable(_: never): never {
   throw new Error("Didn't expect to get here");
 }

--- a/src/data-store/vector-DBs/pineconeVectorDB.ts
+++ b/src/data-store/vector-DBs/pineconeVectorDB.ts
@@ -160,7 +160,7 @@ export class PineconeVectorDB extends VectorDB {
     const PARALLEL_REQUESTS = 5;
     let vectorIdx = 0;
     while (vectorIdx < pineconeVectors.length) {
-      const requests = [];
+      const requests: Promise<void>[] = [];
       for (let i = 0; i < PARALLEL_REQUESTS; i++) {
         const vectors = pineconeVectors.slice(
           vectorIdx,

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -5,7 +5,7 @@ import { BaseRetriever } from "../retrieval/retriever";
 export type GeneratorParams<D> = {
   prompt: JSONValue;
   accessPassport?: AccessPassport;
-  retriever?: BaseRetriever<D>;
+  retriever?: BaseRetriever<D, unknown>;
 };
 
 /**

--- a/src/utils/callbacks.ts
+++ b/src/utils/callbacks.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AccessIdentity } from "../access-control/accessIdentity";
+import { assertUnreachable } from "../common/core";
 import { VectorDBQuery } from "../data-store/vector-DBs/vectorDB";
 import type {
   IngestedDocument,


### PR DESCRIPTION
Adding typescript compile step to CI

There were a few errors still appearing in vscode that were due to typescript compilation errors. These apparently aren't caught w/ just lint or even jest test running, so fixing them & adding a compile step in CI to prevent them from happening again.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/48).
* #49
* __->__ #48