### PR TITLE
Implement Prompt Template Resolution

### DIFF
--- a/__tests__/prompts/promptTemplate.test.ts
+++ b/__tests__/prompts/promptTemplate.test.ts
@@ -1,0 +1,44 @@
+import { PromptTemplate } from "../../src/prompts/prompt-templates/promptTemplate";
+
+describe("promptTemplate resolution", () => {
+  test("should resolve a template with no parameters", () => {
+    const template = new PromptTemplate("Hello, world!");
+    expect(template.resolveTemplate()).toBe("Hello, world!");
+  });
+
+  test("should resolve a template with correct parameters passed in at resolve time", () => {
+    const template = new PromptTemplate(
+      "Hello, {{name}}! Here's some extra context: {{context}}"
+    );
+    expect(
+      template.resolveTemplate({ name: "world", context: "this is a test" })
+    ).toBe("Hello, world! Here's some extra context: this is a test");
+  });
+
+  test("should resolve a template with correct parameters set before resolution", () => {
+    const template = new PromptTemplate(
+      "Hello, {{name}}! Here's some extra context: {{context}}"
+    );
+    template.setParameters({ name: "world", context: "this is a test" });
+    expect(template.resolveTemplate()).toBe(
+      "Hello, world! Here's some extra context: this is a test"
+    );
+  });
+
+  test("parameters set at resolution time take precedence", () => {
+    const template = new PromptTemplate(
+      "Hello, {{name}}! Here's some extra context: {{context}}"
+    );
+    template.setParameters({ name: "world", context: "this is a test" });
+    expect(template.resolveTemplate({ name: "foo", context: "bar" })).toBe(
+      "Hello, foo! Here's some extra context: bar"
+    );
+  });
+
+  test("ignores parameters that are not used in the template", () => {
+    const template = new PromptTemplate("Hello, {{name}}!");
+    expect(
+      template.resolveTemplate({ name: "world", context: "this is a test" })
+    ).toBe("Hello, world!");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/uuid": "^9.0.1",
     "axios": "^1.3.4",
     "d3-dsv": "^2.0.0",
+    "handlebars": "^4.7.8",
     "langchain": "^0.0.153",
     "mammoth": "^1.6.0",
     "mime-types": "^2.1.35",

--- a/src/prompts/prompt-templates/promptTemplate.ts
+++ b/src/prompts/prompt-templates/promptTemplate.ts
@@ -1,3 +1,4 @@
+import { compile } from "handlebars";
 import { IPrompt } from "../prompt";
 
 export type PromptTemplateParameters = { [key: string]: string };
@@ -18,10 +19,9 @@ export class PromptTemplate implements IPrompt {
     this.parameters = params;
   }
 
-  resolveTemplate(_parameters?: PromptTemplateParameters): string {
-    // TODO: Implement using handlebars. Merge parameters with this.parameters and have
-    // method parameters take precedence.
-    return "";
+  resolveTemplate(parameters?: PromptTemplateParameters): string {
+    const compiledTemplate = compile(this.template);
+    return compiledTemplate(parameters ?? this.parameters);
   }
 
   async toString(): Promise<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,6 +2013,18 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
@@ -2896,6 +2908,11 @@ minimatch@^7.1.3:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 ml-array-mean@^1.1.6:
   version "1.1.6"
   resolved "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz"
@@ -2946,6 +2963,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 node-domexception@1.0.0:
   version "1.0.0"
@@ -3680,6 +3702,11 @@ typescript@^4.9.4, typescript@^4.9.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
 underscore@^1.13.1:
   version "1.13.6"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz"
@@ -3798,6 +3825,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Implement Prompt Template Resolution

# Implement Prompt Template Resolution

Prompt templates will be simple class instances which define a template string, using handlebars syntax for parameters. Parameter resolution is done by passing in the params to use (at resolution time or beforehand).

```
ryanholinshead@Ryans-MacBook-Pro semantic-retrieval % yarn test promptTemplate.test.ts
yarn run v1.22.19
$ NODE_OPTIONS='--experimental-vm-modules' jest --runInBand promptTemplate.test.ts
 PASS  __tests__/prompts/promptTemplate.test.ts
  promptTemplate resolution
    ✓ should resolve a template with no parameters (2 ms)
    ✓ should resolve a template with correct parameters passed in at resolve time (2 ms)
    ✓ should resolve a template with correct parameters set before resolution (1 ms)
    ✓ parameters set at resolution time take precedence
    ✓ ignores parameters that are not used in the template

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        0.585 s, estimated 1 s
Ran all test suites matching /promptTemplate.test.ts/i.
✨  Done in 1.46s.
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/56).
* #63
* #62
* #58
* __->__ #56