### PR TITLE
RFC Adding cython to environment.yml for Mac

### DIFF
--- a/python/environment.yml
+++ b/python/environment.yml
@@ -3,5 +3,6 @@ channels:
   - defaults
 dependencies:
   - pip
+  - cython
   - pip:
       - -r requirements.txt


### PR DESCRIPTION
RFC Adding cython to environment.yml for Mac



This fixed a build issue locally on Mac (saw on SO):

https://stackoverflow.com/questions/55164178/failed-building-wheel-for-cchardet-when-installing-datadotworld
