### PR TITLE
CSVRetriever for Structured CSV Data

### DIFF
--- a/__tests__/retrieval/csvRetriever.test.ts
+++ b/__tests__/retrieval/csvRetriever.test.ts
@@ -1,0 +1,56 @@
+import { CSVRetriever } from "../../src/retrieval/csvRetriever";
+
+describe("csvRetriever for retrieving structured data from CSV", () => {
+  test("throws error if primary key column is missing", async () => {
+    const retriever = new CSVRetriever(
+      "examples/example_data/financial_report/portfolios/client_a_portfolio.csv"
+    );
+    await expect(
+      retriever.retrieveData({
+        query: {
+          primaryKeyColumn: "DoesNotExist",
+        },
+      })
+    ).rejects.toThrowError(`Primary key column DoesNotExist missing from row`);
+  });
+
+  test("retrieveData returns correct data from CSV", async () => {
+    const retriever = new CSVRetriever<{
+      [Company: string]: { Shares: number | null };
+    }>(
+      "examples/example_data/financial_report/portfolios/client_a_portfolio.csv"
+    );
+
+    const data = await retriever.retrieveData({
+      query: {
+        primaryKeyColumn: "Company",
+      },
+    });
+
+    expect(data["AAPL"].Shares).toEqual(20);
+    expect(data["MSFT"].Shares).toEqual(null);
+    expect(data["AMZN"].Shares).toEqual(30);
+    expect(data["NVDA"].Shares).toEqual(100);
+    expect(data["GOOGL"].Shares).toEqual(null);
+    expect(data["TSLA"].Shares).toEqual(null);
+    expect(data["GOOG"].Shares).toEqual(null);
+    expect(data["BRK.B"].Shares).toEqual(null);
+    expect(data["META"].Shares).toEqual(null);
+    expect(data["UNH"].Shares).toEqual(30);
+    expect(data["XOM"].Shares).toEqual(null);
+    expect(data["LLY"].Shares).toEqual(null);
+    expect(data["JPM"].Shares).toEqual(null);
+    expect(data["JNJ"].Shares).toEqual(100);
+    expect(data["V"].Shares).toEqual(null);
+    expect(data["PG"].Shares).toEqual(null);
+    expect(data["MA"].Shares).toEqual(null);
+    expect(data["AVGO"].Shares).toEqual(null);
+    expect(data["HD"].Shares).toEqual(null);
+    expect(data["CVX"].Shares).toEqual(null);
+    expect(data["MRK"].Shares).toEqual(40);
+    expect(data["ABBV"].Shares).toEqual(null);
+    expect(data["COST"].Shares).toEqual(null);
+    expect(data["PEP"].Shares).toEqual(200);
+    expect(data["ADBE"].Shares).toEqual(null);
+  });
+});

--- a/src/common/jsonTypes.ts
+++ b/src/common/jsonTypes.ts
@@ -1,7 +1,7 @@
 export type JSONValue = string | number | boolean | JSONObject | JSONArray;
 
 export interface JSONObject {
-  [x: string]: JSONValue | undefined;
+  [x: string]: JSONValue | null | undefined;
 }
 
 export interface JSONArray extends Array<JSONValue> {}

--- a/src/retrieval/csvRetriever.ts
+++ b/src/retrieval/csvRetriever.ts
@@ -1,0 +1,53 @@
+import { JSONObject } from "../common/jsonTypes";
+import { BaseRetriever, BaseRetrieverQueryParams } from "./retriever";
+import fs from "fs/promises";
+import Papa from "papaparse";
+
+export type CSVRetrieverQuery = {
+  // For now, assume a single primary key column
+  primaryKeyColumn: string;
+};
+
+/**
+ * Retrieve structured data from a CSV file as a JSON object for use in completion generation.
+ */
+export class CSVRetriever<R extends JSONObject> extends BaseRetriever<
+  R,
+  CSVRetrieverQuery
+> {
+  filePath: string;
+
+  constructor(filePath: string) {
+    super();
+    this.filePath = filePath;
+  }
+  /**
+   * Get the data relevant to the given query and which the current identity can access.
+   * @param params The retriever query params to use for the query.
+   * @returns A promise that resolves to the retrieved data.
+   */
+  async retrieveData(
+    params: BaseRetrieverQueryParams<CSVRetrieverQuery>
+  ): Promise<R> {
+    const csvString = await (await fs.readFile(this.filePath)).toString();
+    const rows = await Papa.parse<R>(csvString, {
+      header: true,
+      dynamicTyping: true,
+    }).data;
+
+    const retrievedData: JSONObject = {};
+
+    for (const row of rows) {
+      const { [params.query.primaryKeyColumn]: key, ...restRow } = row;
+      if (key == null) {
+        throw new Error(
+          `Primary key column ${params.query.primaryKeyColumn} missing from row`
+        );
+      }
+      const keyVal = typeof key === "string" ? key : JSON.stringify(key);
+      retrievedData[keyVal] = restRow;
+    }
+
+    return retrievedData as R;
+  }
+}


### PR DESCRIPTION
CSVRetriever for Structured CSV Data

# CSVRetriever for Structured CSV Data

Implement a simple CSVRetriever to retrieved structured data from a CSV file for use in the financial report demo. The retriever takes in a file path and primary key name, then retrieves all the rows from the CSV at the file path, keyed by the primary key name

```
ryanholinshead@Ryans-MacBook-Pro semantic-retrieval % yarn test csvRetriever.test.ts
yarn run v1.22.19
$ NODE_OPTIONS='--experimental-vm-modules' jest --runInBand csvRetriever.test.ts
 PASS  __tests__/retrieval/csvRetriever.test.ts
  csvRetriever for retrieving structured data from CSV
    ✓ throws error if primary key column is missing (5 ms)
    ✓ retrieveData returns correct data from CSV (2 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        0.571 s, estimated 1 s
Ran all test suites matching /csvRetriever.test.ts/i.
✨  Done in 1.60s.
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/68).
* #75
* #74
* #73
* #69
* __->__ #68