### PR TITLE
[SR-py] add pydantic-based Record type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .pytest_cache/
 semantic_retrieval.egg-info
 .DS_Store
+**scratch**

--- a/python/src/semantic_retrieval/common/types.py
+++ b/python/src/semantic_retrieval/common/types.py
@@ -1,8 +1,9 @@
 # Don't rely on the generic type. Wrong annotation might be missed.
 # Use `Any` to signal that uncertainty explicitly.
 from typing import Any, TypeVar
-import numpy.typing as npt
 
+import numpy.typing as npt
+from pydantic import BaseModel
 
 # TODO: is this useful?
 NPA = npt.NDArray[Any]
@@ -18,3 +19,9 @@ R = TypeVar("R")
 
 # Canonical typevar for retriever query type
 Q = TypeVar("Q")
+
+
+class Record(BaseModel):
+    class Config:
+        strict = True
+        frozen = True


### PR DESCRIPTION
[SR-py] add pydantic-based Record type

Summary:

We should use strict and immutable, possibly among other configs.
Let's subclass Record instead of BaseModel directly.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/77).
* #82
* __->__ #77