### PR TITLE
[SR-py] add init file for pytest

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,5 @@
+import sys
+
+sys.path.append(".")
+sys.path.append("./src")
+sys.path.append("./src/semantic_retrieval")


### PR DESCRIPTION
[SR-py] add init file for pytest

currently pytest doesnt find modules from inside python/ dir

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/84).
* #87
* #85
* __->__ #84