### PR TITLE
[SR-py] pyright config in root

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,12 @@
+{
+  "typeCheckingMode": "strict",
+  "include": ["python"],
+  "exclude": [],
+  "ignore": [],
+  "venv": "semantic-retrieval",
+  "pythonVersion": "3.11",
+  "reportUnknownMemberType": false,
+  "reportUnknownVariableType": false,
+  "reportUnknownArgumentType": false,
+  "reportMissingTypeStubs": false
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,22 +40,3 @@ exclude = '''
     | dist
   )/
 '''
-
-
-[tool.pyright]
-typeCheckingMode = "strict"
-include = ["src", "tests"]
-exclude = [
-]
-ignore = []
-defineConstant = { DEBUG = true }
-venv = "semantic-retrieval"
-
-# reportMissingImports = true
-# reportMissingTypeStubs = false
-
-reportUnknownMemberType = false
-reportUnknownVariableType = false
-reportUnknownArgumentType = false
-
-pythonVersion = "3.11.5"

--- a/python/src/semantic_retrieval/examples/financial_report/generate_report.py
+++ b/python/src/semantic_retrieval/examples/financial_report/generate_report.py
@@ -9,12 +9,16 @@ from semantic_retrieval.document.metadata.in_memory_document_metadata_db import 
     InMemoryDocumentMetadataDB,
 )
 
-from semantic_retrieval.examples.financial_report.access_control.identities import AdvisorIdentity
+from semantic_retrieval.examples.financial_report.access_control.identities import (
+    AdvisorIdentity,
+)
 from semantic_retrieval.retrieval.csv_retriever import CSVRetriever
 from semantic_retrieval.retrieval.vector_dbs.vector_db_document_retriever import (
     VectorDBDocumentRetriever,
 )
-from semantic_retrieval.retrieval.vector_dbs.vector_db_retriever import VectorDBRetrieverParams
+from semantic_retrieval.retrieval.vector_dbs.vector_db_retriever import (
+    VectorDBRetrieverParams,
+)
 
 from semantic_retrieval.transformation.embeddings.openai_embeddings import (
     OpenAIEmbeddings,


### PR DESCRIPTION
[SR-py] pyright config in root

Summary:

After this, working for SR root seems to work, both at CLI and vscode.

Test:

semantic-retrieval $ pyright
semantic-retrieval $ pytest

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/89).
* #90
* #87
* __->__ #89