### PR TITLE
update_access_control Script & Policy

### DIFF
--- a/examples/typescript/financial_report/components/access_control/adminIdentity.ts
+++ b/examples/typescript/financial_report/components/access_control/adminIdentity.ts
@@ -1,6 +1,6 @@
 import { FinancialReportIdentity } from "./financialReportIdentity";
 
 export class AdminIdentity implements FinancialReportIdentity {
-  resource: "financial_data";
-  role: "admin";
+  resource: "financial_data" = "financial_data";
+  role: "user" | "admin" = "admin";
 }

--- a/examples/typescript/financial_report/components/access_control/advisorIdentity.ts
+++ b/examples/typescript/financial_report/components/access_control/advisorIdentity.ts
@@ -1,11 +1,6 @@
 import { FinancialReportIdentity } from "./financialReportIdentity";
 
 export class AdvisorIdentity implements FinancialReportIdentity {
-  resource: "financial_data";
-  role: "user";
-  client?: string;
-
-  constructor(client: string) {
-    this.client = client;
-  }
+  resource: "financial_data" = "financial_data";
+  role: "user" | "admin" = "user";
 }

--- a/examples/typescript/financial_report/components/access_control/financialReportIdentity.ts
+++ b/examples/typescript/financial_report/components/access_control/financialReportIdentity.ts
@@ -3,5 +3,10 @@ import { AccessIdentity } from "../../../../../src/access-control/accessIdentity
 export interface FinancialReportIdentity extends AccessIdentity {
   resource: "financial_data";
   role: "user" | "admin";
-  client?: string;
+}
+
+export function isFinancialReportIdentity(
+  identity: AccessIdentity
+): identity is FinancialReportIdentity {
+  return identity.resource === "financial_data";
 }

--- a/examples/typescript/financial_report/components/access_control/secretReportAccessPolicy.ts
+++ b/examples/typescript/financial_report/components/access_control/secretReportAccessPolicy.ts
@@ -1,0 +1,25 @@
+import { AccessIdentity } from "../../../../../src/access-control/accessIdentity";
+import { ResourceAccessPolicy } from "../../../../../src/access-control/resourceAccessPolicy";
+import { Document } from "../../../../../src/document/document";
+import { isFinancialReportIdentity } from "./financialReportIdentity";
+
+export const RESOURCE = "financial_data";
+
+export class SecretReportAccessPolicy implements ResourceAccessPolicy {
+  policy = "SecretReportAccessPolicy";
+  resource = RESOURCE;
+
+  async testDocumentReadPermission(
+    _document: Document,
+    requestor?: AccessIdentity
+  ) {
+    if (requestor && isFinancialReportIdentity(requestor)) {
+      return requestor.role === "admin";
+    }
+    return false;
+  }
+
+  async testPolicyPermission(_requestor: AccessIdentity) {
+    return false; // Not needed for this example
+  }
+}

--- a/examples/typescript/financial_report/components/financialReportDocumentRetriever.ts
+++ b/examples/typescript/financial_report/components/financialReportDocumentRetriever.ts
@@ -74,6 +74,7 @@ export class FinancialReportDocumentRetriever
           await Promise.all(
             documentIds.map((documentId) =>
               this.documentRetriever.retrieveData({
+                accessPassport: params.accessPassport,
                 query: {
                   text: params.query,
                   topK: 5,

--- a/examples/typescript/financial_report/ingest_data.ts
+++ b/examples/typescript/financial_report/ingest_data.ts
@@ -21,7 +21,7 @@ async function main() {
     rawDocuments,
     {
       metadataDB,
-      // TODO: This should be a factory that applies User / Admin access policies based on some filter
+      // Always allow by default. Use update_access_control script to change
       accessControlPolicyFactory: new AlwaysAllowDocumentAccessPolicyFactory(),
     }
   );

--- a/examples/typescript/financial_report/update_access_control.ts
+++ b/examples/typescript/financial_report/update_access_control.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env ts-node
+// Description: Script to update access controls in the metadataDB for an ingested financial report document
+// Usage Example: npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a AlwaysAllowAccessPolicy
+
+import { program } from "commander";
+import { AlwaysAllowAccessPolicy } from "../../../src/access-control/policies/alwaysAllowAccessPolicy";
+import { InMemoryDocumentMetadataDB } from "../../../src/document/metadata/inMemoryDocumentMetadataDB";
+import { SecretReportAccessPolicy } from "./components/access_control/secretReportAccessPolicy";
+
+program
+  .name("update_access_control")
+  .description(
+    "Script to update access controls in the metadataDB for an ingested financial report document"
+  );
+
+program.option(
+  "-c, --company <COMPANY>",
+  "specify which company 10k to apply the access control to"
+);
+
+program.option(
+  "-a, --access <ACCESS>",
+  "specify which access control to apply to the company. One of AlwaysAllowAccessPolicy or SecretReportAccessPolicy"
+);
+
+program.parse(process.argv);
+
+async function main() {
+  console.log("Applying access controls to company report...");
+
+  const options = program.opts();
+
+  const company = options.company;
+  if (typeof company !== "string") {
+    throw new Error("company must be specified");
+  }
+
+  const access = options.access;
+  if (typeof access !== "string") {
+    throw new Error("access must be specified");
+  }
+
+  const accessPolicy = getAccessPolicy(access);
+
+  // Load the metadataDB persisted from ingest_data script
+  const metadataDB = await InMemoryDocumentMetadataDB.fromJSONFile(
+    "examples/typescript/financial_report/metadataDB.json"
+  );
+
+  const relevantDocIds = await metadataDB.queryDocumentIds({
+    type: "string_field",
+    fieldName: "name",
+    fieldValue: company,
+    matchType: "includes",
+  });
+
+  if (relevantDocIds.length === 0) {
+    throw new Error(`No documents found for company: ${company}`);
+  }
+
+  await Promise.all(
+    relevantDocIds.map(async (docId) => {
+      const metadata = await metadataDB.getMetadata(docId);
+      metadata.accessPolicies = [accessPolicy];
+      await metadataDB.setMetadata(docId, metadata);
+    })
+  );
+
+  // Persist metadataDB to disk for loading in the other scripts
+  await metadataDB.persist(
+    "examples/typescript/financial_report/metadataDB.json"
+  );
+
+  console.log(
+    "Successfully updated access control for company report documents"
+  );
+}
+
+function getAccessPolicy(access: string) {
+  switch (access) {
+    case "AlwaysAllowAccessPolicy":
+      return new AlwaysAllowAccessPolicy();
+    case "SecretReportAccessPolicy":
+      return new SecretReportAccessPolicy();
+    default:
+      throw new Error(`Unknown access policy: ${access}`);
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done!");
+  })
+  .catch((err: any) => {
+    console.error("Error:", err);
+    process.exit(1);
+  })
+  .finally(() => {
+    process.exit(0);
+  });
+
+export {};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/safe-flat": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
+    "commander": "^11.1.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,11 @@ commander@^10.0.1:
   resolved "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
+commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"


### PR DESCRIPTION
update_access_control Script & Policy

# update_access_control Script & Policy

Implement a simple script which takes in 'company' (ticker) and 'policy' (one of AlwaysAllowAccessPolicy or SecretReportAccessPolicy) and applies the policy to the relevant company documents in the metadataDB.

Using this, we can set individual 10k documents' access policies in the metadata after ingestion and before running generate_report.

## Testing:
- Ran ` npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a SecretReportAccessPolicy` and see updated policy in metadataDB.json on disk. Then run ` npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a AlwaysAllowAccessPolicy` and see metadataDB.json has no changes from main
- Ran `npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a SecretReportAccessPolicy` then ran generate_report and see AAPL section now has: 'There are no specific details provided for Apple Inc. regarding its recovery from the COVID-19 pandemic.'
- Ran `npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a AlwaysAllowAccessPolicy` then ran generate_report to see AAPL section have relevant details again
- Ran `npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a SecretReportAccessPolicy` then ran generate_report and see AAPL section now has: 'There are no specific details provided for Apple Inc. regarding its recovery from the COVID-19 pandemic.'
- Update generate_report to use AdminIdentity and see relevant details for AAPL again

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/119).
* #124
* #121
* __->__ #119