### PR TITLE
Support pre and post model completion request callback

### DIFF
--- a/__tests__/__mocks__/generator/testCompletionModel.ts
+++ b/__tests__/__mocks__/generator/testCompletionModel.ts
@@ -21,12 +21,17 @@ export class TestCompletionModel extends CompletionModel<
   async run(
     params: TestCompletionModelParams
   ): Promise<TestCompletionResponse> {
+    await this.callbackManager?.runCallbacks({
+      name: "onRunCompletionRequest",
+      params,
+    });
+
     const response = {
       completion: "test completion",
     };
 
     await this.callbackManager?.runCallbacks({
-      name: "onRunCompletion",
+      name: "onRunCompletionResponse",
       params,
       response,
     });

--- a/__tests__/utils/callbacks.test.ts
+++ b/__tests__/utils/callbacks.test.ts
@@ -225,12 +225,14 @@ describe("Callbacks", () => {
   });
 
   test("RAG Completion Generator and Completion Model", async () => {
-    const onRunCompletion = jest.fn();
+    const onRunCompletionRequest = jest.fn();
+    const onRunCompletionResponse = jest.fn();
     const onGetRAGCompletionRetrievalQuery = jest.fn();
     const onRunCompletionGeneration = jest.fn();
 
     const callbacks: CallbackMapping = {
-      onRunCompletion: [onRunCompletion],
+      onRunCompletionRequest: [onRunCompletionRequest],
+      onRunCompletionResponse: [onRunCompletionResponse],
       onGetRAGCompletionRetrievalQuery: [onGetRAGCompletionRetrievalQuery],
       onRunCompletionGeneration: [onRunCompletionGeneration],
     };
@@ -251,7 +253,8 @@ describe("Callbacks", () => {
       }),
     });
 
-    expect(onRunCompletion).toHaveBeenCalled();
+    expect(onRunCompletionRequest).toHaveBeenCalled();
+    expect(onRunCompletionResponse).toHaveBeenCalled();
     expect(onGetRAGCompletionRetrievalQuery).toHaveBeenCalled();
     expect(onRunCompletionGeneration).toHaveBeenCalled();
   });

--- a/src/utils/callbacks.ts
+++ b/src/utils/callbacks.ts
@@ -111,8 +111,13 @@ export type GetFragmentsEvent = {
   fragments: DocumentFragment[];
 };
 
-export type RunCompletionEvent = {
-  name: "onRunCompletion";
+export type RunCompletionRequestEvent = {
+  name: "onRunCompletionRequest";
+  params: CompletionModelParams<any>;
+};
+
+export type RunCompletionResponseEvent = {
+  name: "onRunCompletionResponse";
   params: CompletionModelParams<any>;
   response: any;
 };
@@ -150,7 +155,8 @@ type CallbackEvent =
   | RetrieverProcessDocumentsEvent
   | RetrieveDataEvent
   | GetFragmentsEvent
-  | RunCompletionEvent
+  | RunCompletionRequestEvent
+  | RunCompletionResponseEvent
   | RunCompletionGenerationEvent<any>
   | GetRAGCompletionRetrievalQueryEvent;
 
@@ -179,7 +185,8 @@ interface CallbackMapping {
   onRetrieverProcessDocuments?: Callback<RetrieverProcessDocumentsEvent>[];
   onRetrieveData?: Callback<RetrieveDataEvent>[];
   onGetFragments?: Callback<GetFragmentsEvent>[];
-  onRunCompletion?: Callback<RunCompletionEvent>[];
+  onRunCompletionRequest?: Callback<RunCompletionRequestEvent>[];
+  onRunCompletionResponse?: Callback<RunCompletionResponseEvent>[];
   onRunCompletionGeneration?: Callback<RunCompletionGenerationEvent<any>>[];
   onGetRAGCompletionRetrievalQuery?: Callback<GetRAGCompletionRetrievalQueryEvent>[];
 }
@@ -313,11 +320,17 @@ class CallbackManager {
           this.callbacks.onGetFragments,
           DEFAULT_CALLBACKS.onGetFragments
         );
-      case "onRunCompletion":
+      case "onRunCompletionRequest":
         return await this.callback_helper(
           event,
-          this.callbacks.onRunCompletion,
-          DEFAULT_CALLBACKS.onRunCompletion
+          this.callbacks.onRunCompletionRequest,
+          DEFAULT_CALLBACKS.onRunCompletionRequest
+        );
+      case "onRunCompletionResponse":
+        return await this.callback_helper(
+          event,
+          this.callbacks.onRunCompletionResponse,
+          DEFAULT_CALLBACKS.onRunCompletionResponse
         );
       case "onRunCompletionGeneration":
         return await this.callback_helper(


### PR DESCRIPTION
Support pre and post model completion request callback

# Support pre and post model completion request callback

It will be nice to support callback before and after completion request is sent to the model, to support things like logging or request time tracking.

Used for logging in generate_report in next PR

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/130).
* #133
* #132
* #131
* __->__ #130