### PR TITLE
[SR-py] move eval things from script to notebook, fix eval type errors

### DIFF
--- a/python/src/semantic_retrieval/evaluation/metrics.py
+++ b/python/src/semantic_retrieval/evaluation/metrics.py
@@ -1,20 +1,22 @@
 from typing import TypeVar
 from sklearn.metrics import accuracy_score
 
-from semantic_retrieval.evaluation.lib import EvalSetPair, SampleEvalDataset
+from semantic_retrieval.evaluation.lib import IDSetPairEvalDataset, NumericalEvalDataset
+
 
 T = TypeVar("T")
 
-def accuracy_metric(dataset: SampleEvalDataset) -> float:
+def accuracy_metric(dataset: NumericalEvalDataset) -> float:
     return accuracy_score(dataset.ground_truth, dataset.output)  # type: ignore [fixme]
 
 
-def jaccard_similarity(dataset: EvalSetPair[T]) -> float:
+# TODO type this better
+def jaccard_similarity(dataset: IDSetPairEvalDataset) -> float:
     intersection = dataset.input_set & dataset.output_set
     # print(f"{dataset=}")
     union = dataset.input_set | dataset.output_set
     # print(f"{intersection=}, {union=}")
 
-    diff = dataset.input_set - dataset.output_set, dataset.output_set - dataset.input_set
+    # diff = dataset.input_set - dataset.output_set, dataset.output_set - dataset.input_set
     # print(f"missing={diff}")
     return len(intersection) / len(union)

--- a/python/src/semantic_retrieval/examples/financial_report/config.py
+++ b/python/src/semantic_retrieval/examples/financial_report/config.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import logging
 import os
-from typing import List, Type
+from typing import List, Sequence, Type
 
 from dotenv import load_dotenv
 from semantic_retrieval.common.types import Record
@@ -109,3 +109,17 @@ def resolve_path(data_root: str, path: str) -> str:
     """
 
     return os.path.join(os.getcwd(), data_root, path)
+
+
+
+def set_up_script(argv: Sequence[str], loggers: List[logging.Logger]):
+    load_dotenv()
+
+    parser = argparsify(Config)
+    args = parser.parse_args(argv[1:])
+
+    config = get_config(args)
+
+    set_log_level(config.log_level, loggers)
+
+    return args

--- a/python/src/semantic_retrieval/examples/financial_report/evaluate_report.py
+++ b/python/src/semantic_retrieval/examples/financial_report/evaluate_report.py
@@ -1,80 +1,38 @@
 import asyncio
-import json
 import logging
-import os
 import sys
 import re
+from typing import List, Tuple
 
-from typing import Callable, List, Tuple
-from dotenv import load_dotenv
 
 import pandas as pd
 
 from semantic_retrieval.common.core import LOGGER_FMT
-from semantic_retrieval.evaluation.lib import (
-    EvalSetPair,
-    LocalFileSystemGenLLMEvalDataset,
-    SampleEvalDataset,
-    evaluate_sample_local_filesystem,
-    file_contents,
-)
-from semantic_retrieval.evaluation.metrics import accuracy_metric, jaccard_similarity
 
 from semantic_retrieval.examples.financial_report.config import (
-    Config,
-    argparsify,
     get_config,
-    resolve_path,
-    set_log_level,
+    set_up_script,
 )
 
-import sys
 import pandas as pd
 
-from semantic_retrieval.examples.financial_report.evaluate_report import file_contents
-from semantic_retrieval.retrieval.csv_retriever import CSVRetriever
-from semantic_retrieval.common import types
-from semantic_retrieval.evaluation.lib import (
-    LocalFileSystemGenLLMEvalDataset,
-    SampleEvalDataset,
-    local_filesystem_dataset_to_df,
-    Metric
-)
-
-import glob
-import os
 
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(format=LOGGER_FMT)
 
 
-async def main(argv: List[str]):
+async def main(argv: List[str]): # type: ignore
     loggers = [logger]
 
-    args = _set_up_script(argv, loggers)
+    args = set_up_script(argv, loggers)
     config = get_config(args)
     logger.debug("CONFIG:\n")
     logger.debug(str(config))
+    print("Hello world")
+    print("Move of this script is moved to financial_report_eval.ipynb.")
+    # return await run_evaluate_report(config)
 
-    if args.use_v2:
-        return await run_evaluate_report_v2()
-    else:
-        return await run_evaluate_report(config)
-
-
-def _set_up_script(argv, loggers):
-    load_dotenv()
-
-    parser = argparsify(Config)
-    parser.add_argument("--use-v2", action="store_true")
-    args = parser.parse_args(argv[1:])
-
-    config = get_config(args)
-
-    set_log_level(config.log_level, loggers)
-
-    return args
 
 
 def parse_raw_re(s_out: str) -> List[Tuple[str, str, str, str, str]]:
@@ -114,103 +72,46 @@ def gen_output_to_df(s_out: str) -> pd.DataFrame:
     return parse_re_output_to_df(parse_raw_re(s_out))
 
 
-def path_muncher(output_path: str, ground_truth_path: str) -> SampleEvalDataset:
-    logger.debug("HERE" + output_path + "\n" + ground_truth_path)
-    df_gt = pd.read_csv(ground_truth_path)
-    logger.debug(f"GT={df_gt}")
+# def path_muncher(output_path: str, ground_truth_path: str) -> SampleEvalDataset:
+#     logger.debug("HERE" + output_path + "\n" + ground_truth_path)
+#     df_gt = pd.read_csv(ground_truth_path)
+#     logger.debug(f"GT={df_gt}")
 
-    s_out = file_contents(output_path)
-    re_output = parse_raw_re(s_out)
-    df = parse_re_output_to_df(re_output)
+#     s_out = file_contents(output_path)
+#     re_output = parse_raw_re(s_out)
+#     df = parse_re_output_to_df(re_output)
 
-    df_join = df.set_index("ticker").join(
-        df_gt.set_index("ticker"), how="right", lsuffix="_output", rsuffix="_gt"
-    )
+#     df_join = df.set_index("ticker").join(
+#         df_gt.set_index("ticker"), how="right", lsuffix="_output", rsuffix="_gt"
+#     )
 
-    logger.info(f"Outputs and Ground truth:\n{df_join}")
+#     logger.info(f"Outputs and Ground truth:\n{df_join}")
 
-    # TODO this better
-    return SampleEvalDataset(
-        output=df_join.value_millions.tolist(),
-        ground_truth=df_join.net_earnings_millions_2022.tolist(),
-    )
-
-
-async def run_evaluate_report(
-    config: Config,
-):
-    path_output = resolve_path(config.data_root, config.sample_output_path)
-
-    path_ground_truth = resolve_path(
-        config.data_root, config.ticker_eval_ground_truth_path
-    )
-    logger.info(f"Starting evaluation\n{path_ground_truth=}\n{path_output=}")
-    accuracy_pct = 100 * evaluate_sample_local_filesystem(
-        path_output,
-        path_ground_truth,
-        path_muncher,
-        accuracy_metric,
-    )
-
-    print(f"Accuracy: {accuracy_pct:.2f}%")
+    # # TODO this better
+    # return SampleEvalDataset(
+    #     output=df_join.value_millions.tolist(),
+    #     ground_truth=df_join.net_earnings_millions_2022.tolist(),
+    # )
 
 
-
-
-
-
-# TODO
-# def raw_retrieved_chunks_data_muncher_values(
-#     path: str
+# async def run_evaluate_report(
+#     config: Config,
 # ):
-#     contents = file_contents(path)
-#     # logger.debug(f"{contents=}")
-#     obj = json.loads(contents)
-#     return {obj_['company'] for obj_ in obj}
-    
+#     path_output = resolve_path(config.data_root, config.sample_output_path)
 
+#     path_ground_truth = resolve_path(
+#         config.data_root, config.ticker_eval_ground_truth_path
+#     )
+#     logger.info(f"Starting evaluation\n{path_ground_truth=}\n{path_output=}")
+#     accuracy_pct = 100 * evaluate_sample_local_filesystem(
+#         path_output,
+#         path_ground_truth,
+#         path_muncher,
+#         accuracy_metric,
+#     )
 
-async def test_1_2_data_muncher(
-    contents_input: str,
-    contents_output: str    
-):    
-    input_set = raw_retrieved_chunks_data_muncher(contents_input)
-    output_set = completion_model_output_portfolio_data_muncher(contents_output)
-    return EvalSetPair(input_set=input_set, output_set=output_set)
+#     print(f"Accuracy: {accuracy_pct:.2f}%")
 
-async def test_3_4_data_muncher(
-    contents_input: str,
-    contents_output: str    
-):
-    portfolio_set = await portfolio_data_muncher(contents_input)
-    output_set = completion_model_output_portfolio_data_muncher(contents_output) 
-
-    return EvalSetPair(input_set=portfolio_set, output_set=output_set)
-
-async def run_evaluate_report_v2():
-    ROOT_DATA_DIR = "../../../../../examples/example_data/financial_report/"
-    ROOT_DATA_DIR = "examples/example_data/financial_report"
-
-    ARTIFACTS = os.path.join(ROOT_DATA_DIR, "artifacts")
-   
-    TEST_CASES = [
-    (name, os.path.join(ARTIFACTS, ip), os.path.join(ARTIFACTS, op))
-    for name, ip, op in [
-        ("net_income_vs_retrieved", "raw_retrieved_chunks_10k_net_income.json", "portfolio_10k_net_income_report.txt"),
-        ("covid_vs_retrieved", "raw_retrieved_chunks_10k_covid.json", "portfolio_10k_covid_report.txt"),
-    ]
-] + [
-    (name, os.path.join(ROOT_DATA_DIR, ip), os.path.join(ARTIFACTS, op))
-    for name, ip, op in [
-        ("net_income_e2e", "portfolios/sarmad_portfolio.csv", "portfolio_10k_net_income_report.txt"),
-        ("covid_e2e", "portfolios/sarmad_portfolio.csv", "portfolio_10k_covid_report.txt"),                    
-    ]
-]    
-
-    llm_eval_dataset = LocalFileSystemGenLLMEvalDataset.from_list(TEST_CASES)
-    data_munchers = [test_1_2_data_muncher] * 2 + [test_3_4_data_muncher] * 2
-    metrics = [jaccard_similarity] * 4
-    return await evaluate_llm_eval_dataset_local_filesystem(llm_eval_dataset, data_munchers, metrics)
 
 if __name__ == "__main__":
     res = asyncio.run(main(sys.argv))

--- a/python/src/semantic_retrieval/examples/financial_report/financial_report_eval.ipynb
+++ b/python/src/semantic_retrieval/examples/financial_report/financial_report_eval.ipynb
@@ -83,38 +83,32 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "d423fb10-ec9b-4614-b9f6-09a7cff65f58",
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'../../../../../examples/example_data/financial_report/artifacts'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ready\n"
+     ]
     }
    ],
    "source": [
     "import sys\n",
     "import pandas as pd\n",
     "\n",
-    "from semantic_retrieval.examples.financial_report.evaluate_report import file_contents\n",
     "from semantic_retrieval.retrieval.csv_retriever import CSVRetriever\n",
     "from semantic_retrieval.common import types\n",
     "from semantic_retrieval.evaluation.lib import (\n",
     "    LocalFileSystemGenLLMEvalDataset,\n",
-    "    SampleEvalDataset,\n",
-    "    EvalSetPair,\n",
     "    evaluate_llm_eval_dataset_local_filesystem,\n",
     "    evaluate_sample_local_filesystem,\n",
     "    local_filesystem_dataset_to_df,\n",
-    "    Metric\n",
+    "    # LocalFileSystemNumericalEvalDatasetConfig,\n",
+    "    LocalFileSystemIDSetPairEvalDatasetConfig,\n",
+    "    file_contents,\n",
+    "    # IDSetPairEvalDataPathMuncher,\n",
+    "    IDSetPairEvalDataset,\n",
     ")\n",
     "\n",
     "import json\n",
@@ -130,7 +124,9 @@
     "ROOT_DATA_DIR = \"../../../../../examples/example_data/financial_report/\"\n",
     "\n",
     "ARTIFACTS = os.path.join(ROOT_DATA_DIR, \"artifacts\")\n",
-    "ARTIFACTS"
+    "ARTIFACTS\n",
+    "\n",
+    "print(\"Ready\")"
    ]
   },
   {
@@ -258,8 +254,9 @@
     "def raw_retrieved_chunks_data_muncher(\n",
     "    path: str\n",
     "):\n",
+    "    print(f\"{path=}\")\n",
     "    contents = file_contents(path)\n",
-    "    # logger.debug(f\"{contents=}\")\n",
+    "    # print(f\"{contents=}\")\n",
     "    obj = json.loads(contents)\n",
     "    return {obj_['company'] for obj_ in obj}\n",
     "\n",
@@ -277,21 +274,21 @@
     "\n",
     "        \n",
     "async def test_1_2_data_muncher(\n",
-    "    contents_input: str,\n",
-    "    contents_output: str    \n",
+    "    path_input: str,\n",
+    "    path_output: str   \n",
     "):    \n",
-    "    input_set = raw_retrieved_chunks_data_muncher(contents_input)\n",
-    "    output_set = completion_model_output_portfolio_data_muncher(contents_output)\n",
-    "    return EvalSetPair(input_set=input_set, output_set=output_set)\n",
+    "    input_set = raw_retrieved_chunks_data_muncher(path_input)\n",
+    "    output_set = completion_model_output_portfolio_data_muncher(path_output)\n",
+    "    return IDSetPairEvalDataset(input_set=input_set, output_set=output_set)\n",
     "\n",
     "async def test_3_4_data_muncher(\n",
-    "    contents_input: str,\n",
-    "    contents_output: str    \n",
+    "    path_input: str,\n",
+    "    path_output: str    \n",
     "):\n",
-    "    portfolio_set = await portfolio_data_muncher(contents_input)\n",
-    "    output_set = completion_model_output_portfolio_data_muncher(contents_output) \n",
+    "    portfolio_set = await portfolio_data_muncher(path_input)\n",
+    "    output_set = completion_model_output_portfolio_data_muncher(path_output) \n",
     "\n",
-    "    return EvalSetPair(input_set=portfolio_set, output_set=output_set)\n"
+    "    return IDSetPairEvalDataset(input_set=portfolio_set, output_set=output_set)\n"
    ]
   },
   {
@@ -314,7 +311,9 @@
      "text": [
       "Jaccard similarity, input portfolio vs. portfolio of LLM output.\n",
       "\n",
-      "`name` is the test name, and value ranges from 0 (worst) to 1 (perfect).\n"
+      "`name` is the test name, and value ranges from 0 (worst) to 1 (perfect).\n",
+      "path='../../../../../examples/example_data/financial_report/artifacts/raw_retrieved_chunks_10k_net_income.json'\n",
+      "path='../../../../../examples/example_data/financial_report/artifacts/raw_retrieved_chunks_10k_covid.json'\n"
      ]
     },
     {
@@ -388,16 +387,18 @@
     "llm_eval_dataset = LocalFileSystemGenLLMEvalDataset.from_list(TEST_CASES)\n",
     "data_munchers = [test_1_2_data_muncher] * 2 + [test_3_4_data_muncher] * 2\n",
     "metrics = [jaccard_similarity] * 4\n",
-    "await evaluate_llm_eval_dataset_local_filesystem(llm_eval_dataset, data_munchers, metrics)"
+    "\n",
+    "lfs_eval_configs = [\n",
+    "    LocalFileSystemIDSetPairEvalDatasetConfig(\n",
+    "        fn_path_muncher=data_muncher,\n",
+    "        metric=metric\n",
+    "    )\n",
+    "    for data_muncher, metric in zip(data_munchers, metrics)\n",
+    "]\n",
+    "    \n",
+    "\n",
+    "await evaluate_llm_eval_dataset_local_filesystem(llm_eval_dataset, lfs_eval_configs)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d16ff42d-e981-4892-9dea-0e2c6779e3b6",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -509,10 +510,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "22a276a5-23cd-4569-bf11-ad02ca0bcc65",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'completion_generator_input_data' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m input_companies \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m([input_record[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcompany\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m input_record \u001b[38;5;129;01min\u001b[39;00m completion_generator_input_data])\n\u001b[1;32m      2\u001b[0m output_companies \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m(df_report_parsed\u001b[38;5;241m.\u001b[39mticker)\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m input_companies \u001b[38;5;241m==\u001b[39m output_companies\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'completion_generator_input_data' is not defined"
+     ]
+    }
+   ],
    "source": [
     "input_companies = set([input_record['company'] for input_record in completion_generator_input_data])\n",
     "output_companies = set(df_report_parsed.ticker)\n",


### PR DESCRIPTION
[SR-py] move eval things from script to notebook, fix eval type errors

Summary


Has some basic abstractions passing pyright. Example usage in notebook.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/140).
* #141
* __->__ #140