### PR TITLE
Cleaning up Typings to Simplify Class Extensibility

### DIFF
--- a/__tests__/__mocks__/generator/testVectorDBRAGCompletionGenerator.ts
+++ b/__tests__/__mocks__/generator/testVectorDBRAGCompletionGenerator.ts
@@ -3,17 +3,11 @@ import {
   VectorDBRAGCompletionGenerator,
   VectorDBRAGCompletionGeneratorParams,
 } from "../../../src/generator/retrieval-augmented-generation/vectorDBRAGCompletionGenerator";
-import {
-  TestCompletionRequestParams,
-  TestCompletionResponse,
-} from "./testCompletionModel";
+import { TestCompletionModel } from "./testCompletionModel";
 
-export class TestVectorDBRAGCompletionGenerator extends VectorDBRAGCompletionGenerator<
-  TestCompletionRequestParams,
-  TestCompletionResponse
-> {
+export class TestVectorDBRAGCompletionGenerator extends VectorDBRAGCompletionGenerator<TestCompletionModel> {
   async getRetrievalQuery(
-    params: VectorDBRAGCompletionGeneratorParams<TestCompletionRequestParams>
+    params: VectorDBRAGCompletionGeneratorParams<TestCompletionModel>
   ): Promise<VectorDBTextQuery> {
     const query = {
       topK: 1,

--- a/__tests__/evaluation/evaluation.test.ts
+++ b/__tests__/evaluation/evaluation.test.ts
@@ -160,7 +160,10 @@ describe("Retrieval evaluation metrics", () => {
       calculateRetrievedFragmentPrecision,
     ];
 
-    const evalDataset: RetrievalEvaluationDataset<string[], VectorDBQuery> = {
+    const evalDataset: RetrievalEvaluationDataset<
+      VectorDBDocumentRetriever,
+      string[]
+    > = {
       relevantDataByQuery: [[queryParams, relevantFragmentIds]],
     };
 

--- a/examples/typescript/financial_report/components/financialReportDocumentRetriever.ts
+++ b/examples/typescript/financial_report/components/financialReportDocumentRetriever.ts
@@ -1,13 +1,11 @@
 import { JSONObject } from "../../../../src/common/jsonTypes";
-import { VectorDBTextQuery } from "../../../../src/data-store/vector-DBs/vectorDB";
-import { Document } from "../../../../src/document/document";
 import { DocumentMetadataDB } from "../../../../src/document/metadata/documentMetadataDB";
 import { CSVRetriever } from "../../../../src/retrieval/csvRetriever";
-import { DocumentRetriever } from "../../../../src/retrieval/documentRetriever";
 import {
   BaseRetriever,
   BaseRetrieverQueryParams,
 } from "../../../../src/retrieval/retriever";
+import { VectorDBDocumentRetriever } from "../../../../src/retrieval/vector-DBs/vectorDBDocumentRetriever";
 import {
   CallbackManager,
   RetrieveDataEvent,
@@ -18,7 +16,7 @@ export type FinancialReportData = {
   details: string;
 }[];
 
-type FinancialReportQuery = string;
+type FinancialReportQuery = BaseRetrieverQueryParams<string>;
 
 export interface PortfolioData extends JSONObject {
   [Company: string]: { Shares: number | null };
@@ -30,17 +28,17 @@ export interface CompanyProfiles extends JSONObject {
 
 export type FinancialReportDocumentRetrieverConfig = {
   metadataDB: DocumentMetadataDB;
-  documentRetriever: DocumentRetriever<Document[], VectorDBTextQuery>;
+  documentRetriever: VectorDBDocumentRetriever;
   portfolioRetriever: CSVRetriever<PortfolioData>;
   companyProfilesRetriever: CSVRetriever<CompanyProfiles>;
   callbackManager?: CallbackManager;
 };
 
 export class FinancialReportDocumentRetriever
-  extends BaseRetriever<FinancialReportData, FinancialReportQuery>
+  extends BaseRetriever<FinancialReportQuery, FinancialReportData>
   implements FinancialReportDocumentRetrieverConfig
 {
-  documentRetriever: DocumentRetriever<Document[], VectorDBTextQuery>;
+  documentRetriever: VectorDBDocumentRetriever;
   portfolioRetriever: CSVRetriever<PortfolioData>;
   companyProfilesRetriever: CSVRetriever<CompanyProfiles>;
   metadataDB: DocumentMetadataDB;
@@ -56,7 +54,7 @@ export class FinancialReportDocumentRetriever
   // For each of the companies with owned shares in the Portfolio, retrieve embedded documents
   // related to the query from pinecone, and return the details for each company
   async retrieveData(
-    params: BaseRetrieverQueryParams<FinancialReportQuery>
+    params: FinancialReportQuery
   ): Promise<FinancialReportData> {
     const portfolio = await this.portfolioRetriever.retrieveData({
       query: { primaryKeyColumn: "Company" },

--- a/examples/typescript/financial_report/components/financialReportGenerator.ts
+++ b/examples/typescript/financial_report/components/financialReportGenerator.ts
@@ -1,5 +1,8 @@
 import { AccessPassport } from "../../../../src/access-control/accessPassport";
-import { CompletionModelParams } from "../../../../src/generator/completion-models/completionModel";
+import {
+  CompletionModel,
+  CompletionModelParams,
+} from "../../../../src/generator/completion-models/completionModel";
 import { LLMCompletionGenerator } from "../../../../src/generator/completionGenerator";
 import { FinancialReportDocumentRetriever } from "./financialReportDocumentRetriever";
 import {
@@ -16,9 +19,8 @@ interface FinancialReportGeneratorParams extends CompletionModelParams<never> {
   retriever: FinancialReportDocumentRetriever;
 }
 
-export class FinancialReportGenerator<P, R> extends LLMCompletionGenerator<
-  never,
-  Output | Output[],
+export class FinancialReportGenerator extends LLMCompletionGenerator<
+  CompletionModel<never, Output | Output[]>,
   FinancialReportGeneratorParams,
   string
 > {

--- a/src/generator/completion-models/completionModel.ts
+++ b/src/generator/completion-models/completionModel.ts
@@ -7,6 +7,14 @@ export interface CompletionModelParams<P> {
   completionParams?: P;
 }
 
+export type ModelParams<M> = M extends CompletionModel<infer MP, infer _MR>
+  ? MP
+  : never;
+
+export type ModelResponse<M> = M extends CompletionModel<infer _MP, infer MR>
+  ? MR
+  : never;
+
 /**
  * A simple class for interacting with different LLM completion models. CompletionModels
  * are leveraged by CompletionGenerators to generate completions from prompts.

--- a/src/generator/completionGenerator.ts
+++ b/src/generator/completionGenerator.ts
@@ -1,34 +1,44 @@
 import { CallbackManager, Traceable } from "../utils/callbacks";
-import {
-  CompletionModel,
-  CompletionModelParams,
-} from "./completion-models/completionModel";
+import { CompletionModel } from "./completion-models/completionModel";
 
 /**
- * LLM Completion Generators are used for generating some completion response from an LLM
- * based on a prompt and any applicable internal logic. Extend this base class to add
- * additional logic.
+ * A CompletionGenerator generates some response resulting from completion requests to
+ * one or more CompletionModels.
  */
-export abstract class LLMCompletionGenerator<
-  P,
-  R,
-  Q extends CompletionModelParams<P>,
-  F,
-> implements Traceable
-{
-  model: CompletionModel<P, R>;
+export abstract class CompletionGenerator<P, R> implements Traceable {
   callbackManager?: CallbackManager;
 
-  constructor(model: CompletionModel<P, R>, callbackManager?: CallbackManager) {
-    this.model = model;
+  constructor(callbackManager?: CallbackManager) {
     this.callbackManager = callbackManager;
   }
 
   /**
-   * Perform completion generation using the given parameters and return the generated
-   * response data
+   * Perform completion generation using the given parameters and return response
+   * data
    * @param params The parameters to use for generating the completion
    * @returns A promise that resolves to the generated completion data
    */
-  abstract run(params: Q): Promise<F>;
+  abstract run(params: P): Promise<R>;
+}
+
+/**
+ * LLM Completion Generators are used for generating some completion response from an
+ * LLM Completion Model based on input parameters and any applicable internal logic.
+ */
+export abstract class LLMCompletionGenerator<
+    M extends CompletionModel<MP, MR>,
+    P,
+    R,
+    MP = M extends CompletionModel<infer Param, infer _MR> ? Param : never,
+    MR = M extends CompletionModel<MP, infer Result> ? Result : never,
+  >
+  extends CompletionGenerator<P, R>
+  implements Traceable
+{
+  model: M;
+
+  constructor(model: M, callbackManager?: CallbackManager) {
+    super(callbackManager);
+    this.model = model;
+  }
 }

--- a/src/generator/retrieval-augmented-generation/vectorDBRAGCompletionGenerator.ts
+++ b/src/generator/retrieval-augmented-generation/vectorDBRAGCompletionGenerator.ts
@@ -1,31 +1,36 @@
 import {
   VectorDBBaseQuery,
-  VectorDBQuery,
   VectorDBTextQuery,
 } from "../../data-store/vector-DBs/vectorDB";
 import { VectorDBDocumentRetriever } from "../../retrieval/vector-DBs/vectorDBDocumentRetriever";
+import {
+  CompletionModel,
+  ModelParams,
+  ModelResponse,
+} from "../completion-models/completionModel";
 import {
   RAGCompletionGenerator,
   RAGCompletionGeneratorParams,
 } from "./ragCompletionGenerator";
 
-export interface VectorDBRAGCompletionGeneratorParams<P>
-  extends RAGCompletionGeneratorParams<P, VectorDBQuery> {
-  retriever: VectorDBDocumentRetriever;
+export interface VectorDBRAGCompletionGeneratorParams<
+  M extends CompletionModel<ModelParams<M>, ModelResponse<M>>,
+> extends RAGCompletionGeneratorParams<
+    ModelParams<M>,
+    VectorDBDocumentRetriever
+  > {
   retrievalQuery?: VectorDBBaseQuery;
 }
 
 export class VectorDBRAGCompletionGenerator<
-  P,
-  R,
+  M extends CompletionModel<ModelParams<M>, ModelResponse<M>>,
 > extends RAGCompletionGenerator<
-  P,
-  VectorDBTextQuery,
-  R,
-  VectorDBRAGCompletionGeneratorParams<P>
+  M,
+  VectorDBRAGCompletionGeneratorParams<M>,
+  VectorDBDocumentRetriever
 > {
   async getRetrievalQuery(
-    params: VectorDBRAGCompletionGeneratorParams<P>
+    params: VectorDBRAGCompletionGeneratorParams<M>
   ): Promise<VectorDBTextQuery> {
     const { prompt, retrievalQuery } = params;
     const text = typeof prompt === "string" ? prompt : await prompt.toString();

--- a/src/retrieval/csvRetriever.ts
+++ b/src/retrieval/csvRetriever.ts
@@ -12,8 +12,8 @@ export type CSVRetrieverQuery = {
  * Retrieve structured data from a CSV file as a JSON object for use in completion generation.
  */
 export class CSVRetriever<R extends JSONObject> extends BaseRetriever<
-  R,
-  CSVRetrieverQuery
+  BaseRetrieverQueryParams<CSVRetrieverQuery>,
+  R
 > {
   filePath: string;
 

--- a/src/retrieval/documentRetriever.ts
+++ b/src/retrieval/documentRetriever.ts
@@ -19,7 +19,11 @@ import { DocumentMetadataDB } from "../document/metadata/documentMetadataDB";
  * handling is required (e.g. if the underlying source can perform optimized RBAC), but the quality
  * and correctness of the access control logic is the responsibility of the retriever implementation.
  */
-export abstract class DocumentRetriever<R, Q> extends BaseRetriever<R, Q> {
+export abstract class DocumentRetriever<
+  P extends BaseRetrieverQueryParams<Q>,
+  R,
+  Q = P extends BaseRetrieverQueryParams<infer RQ> ? RQ : never,
+> extends BaseRetriever<P, R, Q> {
   metadataDB: DocumentMetadataDB;
 
   constructor(
@@ -186,7 +190,7 @@ export abstract class DocumentRetriever<R, Q> extends BaseRetriever<R, Q> {
    * @param params The retriever query params to use for the query.
    * @returns A promise that resolves to the retrieved data.
    */
-  async retrieveData(params: BaseRetrieverQueryParams<Q>): Promise<R> {
+  async retrieveData(params: P): Promise<R> {
     // By default, just perform a single query to the underlying source and filter the results
     // on access control checks, if applicable
     const unsafeFragments = await this.getFragmentsUnsafe(params);

--- a/src/retrieval/retriever.ts
+++ b/src/retrieval/retriever.ts
@@ -7,10 +7,31 @@ export type BaseRetrieverQueryParams<Q> = {
   query: Q;
 };
 
+export type RetrieverParams<R> = R extends BaseRetriever<infer RP, infer _RR>
+  ? RP
+  : never;
+
+export type RetrieverResponse<R> = R extends BaseRetriever<infer _RQ, infer RR>
+  ? RR
+  : never;
+
+export type RetrieverQuery<R> = R extends BaseRetriever<
+  infer _RP,
+  infer _RR,
+  infer RQ
+>
+  ? RQ
+  : never;
+
 /**
- * Abstract base class for retrieving data R from from an underlying source.
+ * Abstract base class for retrieving data R from from an underlying source based on query Q.
  */
-export abstract class BaseRetriever<R, Q> implements Traceable {
+export abstract class BaseRetriever<
+  P extends BaseRetrieverQueryParams<Q>,
+  R,
+  Q = P extends BaseRetrieverQueryParams<infer RQ> ? RQ : never,
+> implements Traceable
+{
   metadataDB?: DocumentMetadataDB;
   callbackManager?: CallbackManager;
 
@@ -27,5 +48,5 @@ export abstract class BaseRetriever<R, Q> implements Traceable {
    * @param params The retriever query params to use for the query.
    * @returns A promise that resolves to the retrieved data.
    */
-  abstract retrieveData(params: BaseRetrieverQueryParams<Q>): Promise<R>;
+  abstract retrieveData(params: P): Promise<R>;
 }

--- a/src/retrieval/vector-DBs/vectorDBRetriever.ts
+++ b/src/retrieval/vector-DBs/vectorDBRetriever.ts
@@ -26,8 +26,8 @@ export interface VectorDBRetrieverQueryParams
  * Abstract class for retrieving data R from an underlying VectorDB
  */
 export abstract class BaseVectorDBRetriever<R> extends DocumentRetriever<
-  R,
-  VectorDBQuery
+  VectorDBRetrieverQueryParams,
+  R
 > {
   vectorDB: VectorDB;
 


### PR DESCRIPTION
# Cleaning up Typings to Simplify Class Extensibility a bit

Using some type inferencing to clean up the generic for classes a bit. The main core classes (CompletionGenerator, Retriever) only need the params and response types defined as part of their main methods.

Also added inferred type helpers (e.g. `ModelParams`, `RetrieverParams`, etc.) for use in abstract class definitions where needed
