### PR TITLE
Fix Paths in localFileIngestion Example

### DIFF
--- a/typescript/examples/ingestion/localFileIngestion.ts
+++ b/typescript/examples/ingestion/localFileIngestion.ts
@@ -1,15 +1,15 @@
 // TODO: These imports should be from actual lastmile retrieval package
-import { AccessPassport } from "../../../src/access-control/accessPassport";
-import { AlwaysAllowDocumentAccessPolicyFactory } from "../../../src/access-control/alwaysAllowDocumentAccessPolicyFactory";
-import { PineconeVectorDB } from "../../../src/data-store/vector-DBs/pineconeVectorDB";
-import { InMemoryDocumentMetadataDB } from "../../../src/document/metadata/InMemoryDocumentMetadataDB";
-import { FileSystem } from "../../../src/ingestion/data-sources/fs/fileSystem";
-import * as MultiDocumentParser from "../../../src/ingestion/document-parsers/multiDocumentParser";
-import { OpenAIChatModel } from "../../../src/generator/completion-models/openai/openAIChatModel";
-import { VectorDBDocumentRetriever } from "../../../src/retrieval/vector-DBs/vectorDBDocumentRetriever";
-import { SeparatorTextChunker } from "../../../src/transformation/document/text/separatorTextChunker";
-import { OpenAIEmbeddings } from "../../../src/transformation/embeddings/openAIEmbeddings";
-import { VectorDBRAGCompletionGenerator } from "../../../src/generator/retrieval-augmented-generation/vectorDBRAGCompletionGenerator";
+import { AccessPassport } from "../../src/access-control/accessPassport";
+import { AlwaysAllowDocumentAccessPolicyFactory } from "../../src/access-control/alwaysAllowDocumentAccessPolicyFactory";
+import { PineconeVectorDB } from "../../src/data-store/vector-DBs/pineconeVectorDB";
+import { InMemoryDocumentMetadataDB } from "../../src/document/metadata/InMemoryDocumentMetadataDB";
+import { FileSystem } from "../../src/ingestion/data-sources/fs/fileSystem";
+import * as MultiDocumentParser from "../../src/ingestion/document-parsers/multiDocumentParser";
+import { OpenAIChatModel } from "../../src/generator/completion-models/openai/openAIChatModel";
+import { VectorDBDocumentRetriever } from "../../src/retrieval/vector-DBs/vectorDBDocumentRetriever";
+import { SeparatorTextChunker } from "../../src/transformation/document/text/separatorTextChunker";
+import { OpenAIEmbeddings } from "../../src/transformation/embeddings/openAIEmbeddings";
+import { VectorDBRAGCompletionGenerator } from "../../src/generator/retrieval-augmented-generation/vectorDBRAGCompletionGenerator";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -17,7 +17,7 @@ dotenv.config();
 const metadataDB = new InMemoryDocumentMetadataDB();
 
 async function createIndex() {
-  const fileSystem = new FileSystem("examples/example_data/ingestion");
+  const fileSystem = new FileSystem("../examples/example_data/ingestion");
   const rawDocuments = await fileSystem.loadDocuments();
 
   const parsedDocuments = await MultiDocumentParser.parseDocuments(


### PR DESCRIPTION
Fix Paths in localFileIngestion Example

The paths were messed up by the ts file move, so fixing here

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/159).
* #155
* __->__ #159