### PR TITLE
Tweaks to Metadata & AccessPolicy for Source Access Checks

### DIFF
--- a/typescript/__tests__/retrieval/vectorDBRetriever.test.ts
+++ b/typescript/__tests__/retrieval/vectorDBRetriever.test.ts
@@ -81,7 +81,6 @@ const retrievedEmbeddings: VectorEmbedding[] = [
 const alwaysDenyPolicy: ResourceAccessPolicy = {
   policy: "always-deny",
   testDocumentReadPermission: async () => false,
-  testPolicyPermission: async () => false,
 };
 
 mockQuery.mockImplementation(async () => retrievedEmbeddings);

--- a/typescript/examples/financial_report/components/access_control/secretReportAccessPolicy.ts
+++ b/typescript/examples/financial_report/components/access_control/secretReportAccessPolicy.ts
@@ -1,6 +1,7 @@
 import { AccessIdentity } from "../../../../../typescript/src/access-control/accessIdentity";
 import { ResourceAccessPolicy } from "../../../../../typescript/src/access-control/resourceAccessPolicy";
 import { Document } from "../../../../../typescript/src/document/document";
+import { DocumentMetadataDB } from "../../../../src/document/metadata/documentMetadataDB";
 import { isFinancialReportIdentity } from "./financialReportIdentity";
 
 export const RESOURCE = "financial_data";
@@ -11,6 +12,7 @@ export class SecretReportAccessPolicy implements ResourceAccessPolicy {
 
   async testDocumentReadPermission(
     _document: Document,
+    _metadataDB: DocumentMetadataDB,
     requestor?: AccessIdentity
   ) {
     if (requestor && isFinancialReportIdentity(requestor)) {

--- a/typescript/src/access-control/policies/alwaysAllowAccessPolicy.ts
+++ b/typescript/src/access-control/policies/alwaysAllowAccessPolicy.ts
@@ -1,5 +1,6 @@
 import { JSONObject } from "../../common/jsonTypes";
 import { Document } from "../../document/document";
+import { DocumentMetadataDB } from "../../document/metadata/documentMetadataDB";
 import { AccessIdentity } from "../accessIdentity";
 import { ResourceAccessPolicy } from "../resourceAccessPolicy";
 
@@ -9,14 +10,9 @@ export class AlwaysAllowAccessPolicy implements ResourceAccessPolicy {
 
   async testDocumentReadPermission(
     _document: Document,
-    _requestor?: AccessIdentity,
+    _metadataDB: DocumentMetadataDB,
+    _requestor?: AccessIdentity
   ): Promise<boolean> {
-    return true;
-  }
-
-  async testPolicyPermission(
-    _requestor: AccessIdentity,
-  ): Promise<string[] | boolean> {
     return true;
   }
 }

--- a/typescript/src/access-control/resourceAccessPolicy.ts
+++ b/typescript/src/access-control/resourceAccessPolicy.ts
@@ -1,5 +1,6 @@
 import { JSONObject } from "../common/jsonTypes";
 import { Document } from "../document/document";
+import { DocumentMetadataDB } from "../document/metadata/documentMetadataDB";
 import { AccessIdentity } from "./accessIdentity";
 
 /**
@@ -13,24 +14,15 @@ export interface ResourceAccessPolicy {
   /**
    * Tests whether the requestor has read permission for the specified document.
    * @param document - The document to test access for.
+   * @param metadataDB - The metadata database to use for access control.
    * @param requestor - The user identity access to the resource.
-   * @returns true if the user has read access to the document, false otherwise.
+   * @returns true if the user has read access to the document with respect to this policy, false otherwise.
    */
   testDocumentReadPermission: (
     document: Document,
-    requestor?: AccessIdentity,
+    metadataDB: DocumentMetadataDB,
+    requestor?: AccessIdentity
   ) => Promise<boolean>;
-
-  /**
-   * Tests whether the user has read permission for this IAM policy.
-   * This is used to test whether documents can be read by the requestor.
-   * @param requestor - The identity requesting access to the resource.
-   * @returns either a list of permissions that the user has for this scope, or false if the user has no permissions.
-   * @see https://cloud.google.com/resource-manager/reference/rest/v3/organizations/testIamPermissions and https://developers.google.com/drive/api/reference/rest/v3/permissions
-   */
-  testPolicyPermission: (
-    requestor: AccessIdentity,
-  ) => Promise<string[] | boolean>;
 }
 
 /**
@@ -43,7 +35,7 @@ export class ResourceAccessPolicyCache {
 
   get(
     policy: string,
-    requestor: AccessIdentity,
+    requestor: AccessIdentity
   ): string[] | boolean | undefined {
     return this.cache.get(JSON.stringify(requestor) + policy);
   }
@@ -51,7 +43,7 @@ export class ResourceAccessPolicyCache {
   set(
     policy: string,
     requestor: AccessIdentity,
-    permissions: string[] | boolean,
+    permissions: string[] | boolean
   ) {
     this.cache.set(JSON.stringify(requestor) + policy, permissions);
   }

--- a/typescript/src/document/metadata/documentMetadata.ts
+++ b/typescript/src/document/metadata/documentMetadata.ts
@@ -7,6 +7,10 @@ export interface DocumentMetadata {
   rawDocument?: RawDocument;
   document?: Document;
 
+  // The ids of any root documents from the data sources from which this
+  // document was derived (after any number of transformations).
+  sourceDocumentIds?: string[];
+
   collectionId?: string;
 
   uri: string;

--- a/typescript/src/retrieval/documentRetriever.ts
+++ b/typescript/src/retrieval/documentRetriever.ts
@@ -69,11 +69,17 @@ export abstract class DocumentRetriever<R = unknown> extends BaseRetriever {
           return null;
         }
 
+        // TODO: Should we force-check source document policies here before the document itself? Since we
+        // default to hidden, we would require different policies for the source document and any later
+        // documents that don't have access to the rawDocument to check the source (e.g. source document has
+        // policy based on source but transformed document has policy not based on source)
+
         const policyChecks = await Promise.all(
           metadata.accessPolicies.map(async (policy) => ({
             policy,
             passed: await policy.testDocumentReadPermission(
               metadata.document!,
+              this.metadataDB!,
               policy.resource
                 ? accessPassport?.getIdentity(policy.resource)
                 : undefined

--- a/typescript/src/transformation/document/documentTransformer.ts
+++ b/typescript/src/transformation/document/documentTransformer.ts
@@ -35,10 +35,21 @@ export abstract class BaseDocumentTransformer
       const transformedDocument = await this.transformDocument(document);
       const originalDocumentMetadata =
         await this.documentMetadataDB?.getMetadata(document.documentId);
+
+      let sourceDocumentIds;
+      if (originalDocumentMetadata?.rawDocument != null) {
+        // Pre-transformed doc was ingested from a raw document so it is the 'source' document
+        sourceDocumentIds = [document.documentId];
+      } else {
+        // Pre-transformed doc may have source documents from previous transformations
+        sourceDocumentIds = originalDocumentMetadata?.sourceDocumentIds;
+      }
+
       await this.documentMetadataDB?.setMetadata(
         transformedDocument.documentId,
         {
           ...originalDocumentMetadata,
+          sourceDocumentIds,
           documentId: transformedDocument.documentId,
           document: transformedDocument,
           uri: originalDocumentMetadata?.uri ?? transformedDocument.documentId,


### PR DESCRIPTION
# Tweaks to Metadata & AccessPolicy for Source Access Checks

When working on the example this week, I realized this V1 RBAC implementation is missing some info needed for checks of the source for a document:
- Need to track the source document ids for any document that may be a product of any number of transformations. Technically a document could have been transformed by combining contents of multiple sources, so using an array for the ids to handle that
- Pass metadata db reference through the access checks so that it can do more complex checks like checking the original ingested document source (without having to proliferate data sources throughout transformed document metadata), and can do a union of checks if there are multiple sources used to obtain the transformed document

I'm not a big fan of passing the metadataDB and having the source check put on the policy, but it will do for now. We're expecting a V3 RBAC update which will likely change this implementation quite a bit anyway