### PR TITLE
Set sourceIds in transformDocuments

### DIFF
--- a/typescript/src/transformation/document/documentTransformer.ts
+++ b/typescript/src/transformation/document/documentTransformer.ts
@@ -36,19 +36,20 @@ export abstract class BaseDocumentTransformer
       const originalDocumentMetadata =
         await this.documentMetadataDB?.getMetadata(document.documentId);
 
-      let sourceDocumentIds;
-      if (originalDocumentMetadata?.rawDocument != null) {
+      // Pre-transformed doc may have source documents from previous transformations
+      let sourceDocumentIds = originalDocumentMetadata?.sourceDocumentIds;
+      if (
+        (sourceDocumentIds == null || sourceDocumentIds.length === 0) &&
+        originalDocumentMetadata?.rawDocument != null
+      ) {
         // Pre-transformed doc was ingested from a raw document so it is the 'source' document
         sourceDocumentIds = [document.documentId];
-      } else {
-        // Pre-transformed doc may have source documents from previous transformations
-        sourceDocumentIds = originalDocumentMetadata?.sourceDocumentIds;
       }
 
       await this.documentMetadataDB?.setMetadata(
         transformedDocument.documentId,
         {
-          ...originalDocumentMetadata,
+          ...originalDocumentMetadata, // TODO: Probably only need a subset (e.g. accessPolicies), excluding rawDocument
           sourceDocumentIds,
           documentId: transformedDocument.documentId,
           document: transformedDocument,


### PR DESCRIPTION
# Set sourceIds in transformDocuments

Fix setting sourceIds in the case that rawDocument is propagated across transformed docs. Also added a TODO to remove that propagation of rawDocument now that souceDocumentIds can be used
