### PR TITLE
Updates to work with Python Interop

### DIFF
--- a/typescript/examples/financial_report/components/financialReportDocumentRetriever.ts
+++ b/typescript/examples/financial_report/components/financialReportDocumentRetriever.ts
@@ -69,7 +69,7 @@ export class FinancialReportDocumentRetriever
         company,
         documentIds: await this.metadataDB.queryDocumentIds({
           type: "string_field",
-          fieldName: "name",
+          fieldName: "uri",
           fieldValue: company,
           matchType: "includes",
         }),

--- a/typescript/examples/financial_report/update_access_control.ts
+++ b/typescript/examples/financial_report/update_access_control.ts
@@ -3,8 +3,8 @@
 // Usage Example: npx ts-node examples/typescript/financial_report/update_access_control.ts -c AAPL -a AlwaysAllowAccessPolicy
 
 import { program } from "commander";
-import { AlwaysAllowAccessPolicy } from "../../../src/access-control/policies/alwaysAllowAccessPolicy";
-import { InMemoryDocumentMetadataDB } from "../../../src/document/metadata/inMemoryDocumentMetadataDB";
+import { AlwaysAllowAccessPolicy } from "../../src/access-control/policies/alwaysAllowAccessPolicy";
+import { InMemoryDocumentMetadataDB } from "../../src/document/metadata/inMemoryDocumentMetadataDB";
 import { SecretReportAccessPolicy } from "./components/access_control/secretReportAccessPolicy";
 
 program
@@ -44,12 +44,12 @@ async function main() {
 
   // Load the metadataDB persisted from ingest_data script
   const metadataDB = await InMemoryDocumentMetadataDB.fromJSONFile(
-    "examples/typescript/financial_report/metadataDB.json"
+    "examples/financial_report/metadataDB.json"
   );
 
   const relevantDocIds = await metadataDB.queryDocumentIds({
     type: "string_field",
-    fieldName: "name",
+    fieldName: "uri",
     fieldValue: company,
     matchType: "includes",
   });
@@ -67,9 +67,7 @@ async function main() {
   );
 
   // Persist metadataDB to disk for loading in the other scripts
-  await metadataDB.persist(
-    "examples/typescript/financial_report/metadataDB.json"
-  );
+  await metadataDB.persist("examples/financial_report/metadataDB.json");
 
   console.log(
     "Successfully updated access control for company report documents"

--- a/typescript/src/document/metadata/inMemoryDocumentMetadataDB.ts
+++ b/typescript/src/document/metadata/inMemoryDocumentMetadataDB.ts
@@ -1,4 +1,5 @@
 import { DocumentMetadata } from "./documentMetadata";
+import { Document } from "../document";
 import {
   DocumentMetadataDB,
   DocumentMetadataDBQuery,
@@ -78,6 +79,20 @@ export class InMemoryDocumentMetadataDB implements DocumentMetadataDB {
   ): Promise<InMemoryDocumentMetadataDB> {
     const json = await (await fs.readFile(filePath)).toString();
     const map = JSON.parse(json, deserializer);
+    (Object.values(map) as DocumentMetadata[]).forEach((metadata) => {
+      if (!metadata.document) {
+        metadata.document = {
+          documentId: metadata.documentId,
+          collectionId: metadata.collectionId,
+          fragments: [],
+          serialize: async () => {
+            throw new Error(
+              "Unable to serialize document with partial data from metadataDB"
+            );
+          },
+        } as Document;
+      }
+    });
     return new InMemoryDocumentMetadataDB(map);
   }
 }


### PR DESCRIPTION
# Updates to work with Python Interop

Use `uri` instead of `name` for file path lookups & revive a Document when deserializing from metadataDB json if none exists (using the metadata itself) to allow access checks in `documentRetriever` to work
