### PR TITLE
CallbackManager For ingest_data

### DIFF
--- a/typescript/__tests__/__utils__/testDocumentUtils.ts
+++ b/typescript/__tests__/__utils__/testDocumentUtils.ts
@@ -93,7 +93,7 @@ export function getTestRawDocument(
     documentId,
     uri: "test-source-uri",
     name: "test-raw-doc-name",
-    dataSource: config?.dataSource ?? new FileSystem("test"),
+    dataSource: config?.dataSource ?? new FileSystem({ path: "test" }),
     mimeType: "text/plain",
     getChunkedContent: async () =>
       config?.chunkedContent ?? [

--- a/typescript/__tests__/data-store/vector-DBs/pineconeVectorDB.test.ts
+++ b/typescript/__tests__/data-store/vector-DBs/pineconeVectorDB.test.ts
@@ -273,7 +273,7 @@ describe("pineconeVectorDB query", () => {
     const onQueryVectorDBCallback = jest.fn();
 
     const callbacks: CallbackMapping = {
-      onAddDocumentToVectorDB: [onAddDocumentToVectorDBCallback],
+      onAddDocumentsToVectorDB: [onAddDocumentToVectorDBCallback],
       onQueryVectorDB: [onQueryVectorDBCallback],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);

--- a/typescript/__tests__/ingestion/data-sources/fileSystem.test.ts
+++ b/typescript/__tests__/ingestion/data-sources/fileSystem.test.ts
@@ -80,7 +80,7 @@ async function validateDocxRawDocument(rawDocument: RawDocument) {
 describe("FileSystem data source", () => {
   test("individual txt file", async () => {
     const path = resolveExamplesPath("DonQuixote.txt");
-    const fileSystem = new FileSystem(path);
+    const fileSystem = new FileSystem({ path });
     const rawDocuments = await fileSystem.loadDocuments();
 
     expect(rawDocuments.length).toBe(1);
@@ -89,7 +89,9 @@ describe("FileSystem data source", () => {
 
   test("directory", async () => {
     const directoryPath = resolveExamplesPath();
-    const rawDocuments = await new FileSystem(directoryPath).loadDocuments();
+    const rawDocuments = await new FileSystem({
+      path: directoryPath,
+    }).loadDocuments();
     expect(rawDocuments.length).toBe(4);
 
     await validateTxtRawDocument(rawDocuments[0]);

--- a/typescript/__tests__/ingestion/document-parsers/directDocumentParser.test.ts
+++ b/typescript/__tests__/ingestion/document-parsers/directDocumentParser.test.ts
@@ -18,14 +18,14 @@ classical Latin literature from 45 BC, making it over 2000 years old. Richard Mc
 professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, 
 consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, 
 discovered the undoubtable source. 
-`
+`;
 
 const testRawContent3 = `
 Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 
 "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book 
 is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 
 "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
-`
+`;
 
 const rawDocument1: RawDocument = {
   metadata: {},
@@ -33,7 +33,7 @@ const rawDocument1: RawDocument = {
   documentId: "rawDoc1Id",
   uri: "rawDoc1Uri",
   name: "rawDoc1Name",
-  dataSource: new FileSystem("test"),
+  dataSource: new FileSystem({ path: "test" }),
   mimeType: "text/plain",
   getChunkedContent: async () => [
     {
@@ -50,7 +50,7 @@ const rawDocument2: RawDocument = {
   documentId: "rawDoc2Id",
   uri: "rawDoc2Uri",
   name: "rawDoc2Name",
-  dataSource: new FileSystem("test"),
+  dataSource: new FileSystem({ path: "test" }),
   mimeType: "text/plain",
   getChunkedContent: async () => [
     {
@@ -68,7 +68,6 @@ const rawDocument2: RawDocument = {
   ],
   getContent: async () => testRawContent2,
 };
-
 
 describe("DirectDocument parser", () => {
   test("parse single RawDocumentChunk into matching DocumentFragment", async () => {

--- a/typescript/__tests__/utils/callbacks.test.ts
+++ b/typescript/__tests__/utils/callbacks.test.ts
@@ -37,12 +37,10 @@ describe("Callbacks", () => {
       onLoadDocumentsSuccess: [onLoadDocumentsSuccessCallback1],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);
-    const fileSystem = new FileSystem(
-      "../examples/example_data/ingestion/DonQuixote.txt",
-      undefined,
-      undefined,
-      callbackManager
-    );
+    const fileSystem = new FileSystem({
+      path: "../examples/example_data/ingestion/DonQuixote.txt",
+      callbackManager,
+    });
     await fileSystem.loadDocuments();
 
     // This test passes by virtue of static type checking. No dynamic condition to check.
@@ -57,12 +55,10 @@ describe("Callbacks", () => {
       onLoadDocumentsError: [onLoadDocumentsErrorCallback1],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);
-    const fileSystem = new FileSystem(
-      "../examples/example_data/ingestion/DonQuixote.txt",
-      undefined,
-      undefined,
-      callbackManager
-    );
+    const fileSystem = new FileSystem({
+      path: "../examples/example_data/ingestion/DonQuixote.txt",
+      callbackManager,
+    });
 
     await fileSystem.loadDocuments();
 
@@ -82,12 +78,10 @@ describe("Callbacks", () => {
       onDataSourceTestConnectionError: [onTestConnectionErrorCallback1],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);
-    const fileSystem = new FileSystem(
-      "../examples/example_data/ingestion/DonQuixote.txt",
-      undefined,
-      undefined,
-      callbackManager
-    );
+    const fileSystem = new FileSystem({
+      path: "../examples/example_data/ingestion/DonQuixote.txt",
+      callbackManager,
+    });
 
     await fileSystem.testConnection();
 
@@ -108,11 +102,7 @@ describe("Callbacks", () => {
       onParseSuccess: [onParseSuccessCallback1],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);
-    const documentParser = new DirectDocumentParser(
-      undefined,
-      undefined,
-      callbackManager
-    );
+    const documentParser = new DirectDocumentParser({ callbackManager });
 
     try {
       await documentParser.parse(getTestRawDocument());

--- a/typescript/__tests__/utils/vectorDBCallbacks.test.ts
+++ b/typescript/__tests__/utils/vectorDBCallbacks.test.ts
@@ -1,11 +1,6 @@
-import { PineconeVectorDB } from "../../src/data-store/vector-DBs/pineconeVectorDB";
 import { InMemoryDocumentMetadataDB } from "../../src/document/metadata/inMemoryDocumentMetadataDB";
-
-// TODO: Should probably move the callback handler tests for pinecone into separate file
-import { Pinecone } from "@pinecone-database/pinecone";
 import { DirectDocumentParser } from "../../src/ingestion/document-parsers/directDocumentParser";
 import { CallbackManager, CallbackMapping } from "../../src/utils/callbacks";
-import { TestEmbeddings } from "../__mocks__/transformation/embeddings/testEmbeddings";
 import { getTestRawDocument } from "../__utils__/testDocumentUtils";
 import TestVectorDB from "../__mocks__/retrieval/testVectorDB";
 
@@ -15,13 +10,12 @@ describe("VectorDBCallbacks", () => {
     const onQueryVectorDBCallback = jest.fn();
 
     const callbacks: CallbackMapping = {
-      onAddDocumentToVectorDB: [onAddDocumentToVectorDBCallback],
+      onAddDocumentsToVectorDB: [onAddDocumentToVectorDBCallback],
       onQueryVectorDB: [onQueryVectorDBCallback],
     };
     const callbackManager = new CallbackManager("rag-run-0", callbacks);
     const documentParser = new DirectDocumentParser();
 
-    const embeddingsTransformer = new TestEmbeddings();
     const documentMetadataDB = new InMemoryDocumentMetadataDB();
 
     const testVectorDB = new TestVectorDB(documentMetadataDB);

--- a/typescript/examples/financial_report/ingest_data.ts
+++ b/typescript/examples/financial_report/ingest_data.ts
@@ -2,7 +2,7 @@
 // Description: Script to ingest 10k financial report documents into a Pinecone index and serialize associated metadata to disk
 // Usage Example: npx ts-node examples/typescript/financial_report/ingest_data.ts -p my-index
 
-import { program } from "commander";
+import { OptionValues, program } from "commander";
 import { FileSystem } from "../../src/ingestion/data-sources/fs/fileSystem";
 import * as MultiDocumentParser from "../../src/ingestion/document-parsers/multiDocumentParser";
 import dotenv from "dotenv";
@@ -12,6 +12,15 @@ import { SeparatorTextChunker } from "../../src/transformation/document/text/sep
 import { PineconeVectorDB } from "../../src/data-store/vector-DBs/pineconeVectorDB";
 import { OpenAIEmbeddings } from "../../src/transformation/embeddings/openAIEmbeddings";
 import { v4 as uuid } from "uuid";
+import {
+  AddDocumentsToVectorDBEvent,
+  CallbackManager,
+  LoadChunkedContentEvent,
+  LoadDocumentsSuccessEvent,
+  ParseSuccessEvent,
+  TransformDocumentEvent,
+  TransformDocumentsEvent,
+} from "../../../typescript/src/utils/callbacks";
 
 dotenv.config();
 
@@ -28,20 +37,22 @@ program.option(
   "examples" // default pinecone index name
 );
 
+program.option("-v, --verbose", "specify whether to print verbose logs", false);
+
 program.parse(process.argv);
 
 async function main() {
   console.log("Starting ingestion...");
 
   const options = program.opts();
-  const { pinecone_index: indexName } = options;
-  if (typeof indexName !== "string") {
-    throw new Error("no index name or default specified");
-  }
+  const { indexName, verboseLogging } = getOptions(options);
 
-  const fileSystem = new FileSystem(
-    "../examples/example_data/financial_report/10ks"
-  );
+  const callbackManager = getLoggingCallbackManager(verboseLogging);
+
+  const fileSystem = new FileSystem({
+    path: "../examples/example_data/financial_report/10ks",
+    callbackManager,
+  });
   const rawDocuments = await fileSystem.loadDocuments();
   const metadataDB = new InMemoryDocumentMetadataDB();
 
@@ -51,16 +62,17 @@ async function main() {
       metadataDB,
       // Always allow by default. Use update_access_control script to change
       accessControlPolicyFactory: new AlwaysAllowDocumentAccessPolicyFactory(),
+      callbackManager,
     }
   );
 
-  const documentTransformer = new SeparatorTextChunker({ metadataDB });
+  const documentTransformer = new SeparatorTextChunker({
+    metadataDB,
+    callbackManager,
+  });
+
   const transformedDocuments =
     await documentTransformer.transformDocuments(parsedDocuments);
-
-  console.log(
-    `Transformed ${transformedDocuments.length} documents for ingestion`
-  );
 
   // Persist metadataDB to disk for loading in the other scripts
   await metadataDB.persist("examples/financial_report/metadataDB.json");
@@ -76,6 +88,7 @@ async function main() {
     namespace,
     embeddings: new OpenAIEmbeddings(),
     metadataDB,
+    callbackManager,
   });
 
   console.log("Upserting document embeddings to Pinecone index...");
@@ -83,6 +96,94 @@ async function main() {
   await vectorDB.addDocuments(transformedDocuments);
 
   console.log("Ingestion complete");
+}
+
+function getLoggingCallbackManager(verboseLogging: boolean) {
+  return new CallbackManager(`ingest-data-${uuid()}`, {
+    onLoadChunkedContent: [
+      async (event: LoadChunkedContentEvent) => {
+        if (verboseLogging) {
+          console.log(
+            `Loaded ${event.chunkedContent.length} chunks from ${event.path} via ${event.loader.constructor.name}: `,
+            event.chunkedContent
+          );
+        } else {
+          console.log(
+            `Loaded ${event.chunkedContent.length} chunks from ${event.path} via ${event.loader.constructor.name}`
+          );
+        }
+      },
+    ],
+    onLoadDocumentsSuccess: [
+      async (event: LoadDocumentsSuccessEvent) => {
+        if (verboseLogging) {
+          console.log(
+            `Successfully loaded ${event.rawDocuments.length} documents from ${event.dataSource.name}: `,
+            event.dataSource,
+            event.rawDocuments
+          );
+        } else {
+          console.log(
+            `Successfully loaded ${event.rawDocuments.length} documents from ${event.dataSource.name}`
+          );
+        }
+      },
+    ],
+    onParseSuccess: [
+      async (event: ParseSuccessEvent) => {
+        if (verboseLogging) {
+          console.log(
+            `Parsed ${event.ingestedDocument.rawDocument.uri}: `,
+            event.ingestedDocument
+          );
+        } else {
+          console.log(
+            `Parsed ${event.ingestedDocument.rawDocument.uri} into ${event.ingestedDocument.fragments.length} fragments`
+          );
+        }
+      },
+    ],
+    onTransformDocument: [
+      async (event: TransformDocumentEvent) => {
+        if (verboseLogging) {
+          console.log(
+            `Transformed document ${event.originalDocument.documentId} to ${event.transformedDocument.documentId}`,
+            event.originalDocument,
+            event.transformedDocument
+          );
+        } else {
+          console.log(
+            `Transformed document ${event.originalDocument.documentId} to ${event.transformedDocument.documentId}`
+          );
+        }
+      },
+    ],
+    onTransformDocuments: [
+      async (event: TransformDocumentsEvent) => {
+        console.log(
+          `Transformed ${event.originalDocuments.length} documents for ingestion`
+        );
+      },
+    ],
+    onAddDocumentsToVectorDB: [
+      async (event: AddDocumentsToVectorDBEvent) => {
+        console.log(`Upserted ${event.documents.length} documents to Pinecone`);
+      },
+    ],
+  });
+}
+
+function getOptions(options: OptionValues) {
+  const { pinecone_index: indexName, verbose } = options;
+
+  if (typeof indexName !== "string") {
+    throw new Error("no index name or default specified");
+  }
+
+  return {
+    indexName,
+    verboseLogging: verbose !== false,
+  };
 }
 
 main()

--- a/typescript/examples/ingestion/localFileIngestion.ts
+++ b/typescript/examples/ingestion/localFileIngestion.ts
@@ -17,7 +17,9 @@ dotenv.config();
 const metadataDB = new InMemoryDocumentMetadataDB();
 
 async function createIndex() {
-  const fileSystem = new FileSystem("../examples/example_data/ingestion");
+  const fileSystem = new FileSystem({
+    path: "../examples/example_data/ingestion",
+  });
   const rawDocuments = await fileSystem.loadDocuments();
 
   const parsedDocuments = await MultiDocumentParser.parseDocuments(

--- a/typescript/src/data-store/vector-DBs/pineconeVectorDB.ts
+++ b/typescript/src/data-store/vector-DBs/pineconeVectorDB.ts
@@ -41,7 +41,7 @@ export class PineconeVectorDB extends VectorDB {
   namespace: Index<RecordMetadata>;
 
   constructor(config: PineconeVectorDBConfig) {
-    super(config.embeddings, config.metadataDB);
+    super(config.embeddings, config.metadataDB, config.callbackManager);
 
     const apiKey = config?.apiKey ?? getEnvVar("PINECONE_API_KEY");
     if (!apiKey) {

--- a/typescript/src/data-store/vector-DBs/vectorDB.ts
+++ b/typescript/src/data-store/vector-DBs/vectorDB.ts
@@ -50,6 +50,7 @@ export function isTextQuery(query: VectorDBQuery): query is VectorDBTextQuery {
 export interface VectorDBConfig {
   embeddings: EmbeddingsTransformer;
   metadataDB: DocumentMetadataDB;
+  callbackManager?: CallbackManager;
 }
 
 /**
@@ -67,10 +68,12 @@ export abstract class VectorDB implements VectorDBConfig, Traceable {
 
   constructor(
     embeddings: EmbeddingsTransformer,
-    metadataDB: DocumentMetadataDB
+    metadataDB: DocumentMetadataDB,
+    callbackManager?: CallbackManager
   ) {
     this.embeddings = embeddings;
     this.metadataDB = metadataDB;
+    this.callbackManager = callbackManager;
   }
 
   static async fromDocuments(

--- a/typescript/src/document/metadata/inMemoryDocumentMetadataDB.ts
+++ b/typescript/src/document/metadata/inMemoryDocumentMetadataDB.ts
@@ -66,6 +66,9 @@ export class InMemoryDocumentMetadataDB implements DocumentMetadataDB {
           if (key === "previousFragment" || key === "nextFragment") {
             return;
           }
+          if (key === "callbacks") {
+            return;
+          }
           if (!options?.persistFragments && key === "fragments") {
             return [];
           }

--- a/typescript/src/ingestion/data-sources/fs/csvFileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/csvFileLoader.ts
@@ -1,13 +1,16 @@
 import { CSVLoader } from "langchain/document_loaders/fs/csv";
-import { LangChainFileLoader } from "./langchainFileLoader";
+import {
+  LangChainFileLoader,
+  LangChainFileLoaderOptions,
+} from "./langchainFileLoader";
 
-type LangChainCSVLoaderOptions = {
+type LangChainCSVLoaderOptions = LangChainFileLoaderOptions & {
   column?: string;
   separator?: string;
 };
 
 export class CSVFileLoader extends LangChainFileLoader {
   constructor(path: string, options?: LangChainCSVLoaderOptions) {
-    super(path, new CSVLoader(path, options));
+    super(path, new CSVLoader(path, options), options);
   }
 }

--- a/typescript/src/ingestion/data-sources/fs/docxFileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/docxFileLoader.ts
@@ -1,8 +1,11 @@
 import { DocxLoader } from "langchain/document_loaders/fs/docx";
-import { LangChainFileLoader } from "./langchainFileLoader";
+import {
+  LangChainFileLoader,
+  LangChainFileLoaderOptions,
+} from "./langchainFileLoader";
 
 export class DocxFileLoader extends LangChainFileLoader {
-  constructor(path: string) {
-    super(path, new DocxLoader(path));
+  constructor(path: string, options?: LangChainFileLoaderOptions) {
+    super(path, new DocxLoader(path), options);
   }
 }

--- a/typescript/src/ingestion/data-sources/fs/fileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/fileLoader.ts
@@ -1,14 +1,17 @@
 import { RawDocumentChunk } from "../../../document/document";
+import { CallbackManager, Traceable } from "../../../utils/callbacks";
 
 /**
  * Abstract class for loading chunked content from a file.
  */
-export abstract class BaseFileLoader {
-    path: string;
-  
-    constructor(path: string) {
-      this.path = path;
-    }
-  
-    abstract loadChunkedContent(): Promise<RawDocumentChunk[]>;
+export abstract class BaseFileLoader implements Traceable {
+  path: string;
+  callbackManager?: CallbackManager;
+
+  constructor(path: string, callbackManager?: CallbackManager) {
+    this.path = path;
+    this.callbackManager = callbackManager;
   }
+
+  abstract loadChunkedContent(): Promise<RawDocumentChunk[]>;
+}

--- a/typescript/src/ingestion/data-sources/fs/langchainFileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/langchainFileLoader.ts
@@ -1,6 +1,14 @@
 import { BaseDocumentLoader } from "langchain/dist/document_loaders/base";
 import { BaseFileLoader } from "./fileLoader";
 import { RawDocumentChunk } from "../../../document/document";
+import {
+  CallbackManager,
+  LoadChunkedContentEvent,
+} from "../../../utils/callbacks";
+
+export type LangChainFileLoaderOptions = {
+  callbackManager?: CallbackManager;
+};
 
 /**
  * Abstract class for loading RawDocuments from a file using
@@ -8,10 +16,16 @@ import { RawDocumentChunk } from "../../../document/document";
  */
 export abstract class LangChainFileLoader extends BaseFileLoader {
   loader: BaseDocumentLoader;
+  callbackManager?: CallbackManager;
 
-  constructor(path: string, loader: BaseDocumentLoader) {
+  constructor(
+    path: string,
+    loader: BaseDocumentLoader,
+    options?: LangChainFileLoaderOptions
+  ) {
     super(path);
     this.loader = loader;
+    this.callbackManager = options?.callbackManager;
   }
 
   // LangChain loaders return Document object(s) with pageContent and metadata.
@@ -19,9 +33,20 @@ export abstract class LangChainFileLoader extends BaseFileLoader {
   // is chunked (e.g. by pages)
   async loadChunkedContent(): Promise<RawDocumentChunk[]> {
     const documents = await this.loader.load();
-    return documents.map((document) => ({
+    const chunkedContent = documents.map((document) => ({
       content: document.pageContent,
       metadata: document.metadata,
     }));
+
+    const event: LoadChunkedContentEvent = {
+      name: "onLoadChunkedContent",
+      chunkedContent,
+      path: this.path,
+      loader: this.loader,
+    };
+
+    await this.callbackManager?.runCallbacks(event);
+
+    return chunkedContent;
   }
 }

--- a/typescript/src/ingestion/data-sources/fs/pdfFileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/pdfFileLoader.ts
@@ -1,8 +1,11 @@
 import { PDFLoader } from "langchain/document_loaders/fs/pdf";
-import { LangChainFileLoader } from "./langchainFileLoader";
+import {
+  LangChainFileLoader,
+  LangChainFileLoaderOptions,
+} from "./langchainFileLoader";
 
 export class PDFFileLoader extends LangChainFileLoader {
-  constructor(path: string) {
-    super(path, new PDFLoader(path));
+  constructor(path: string, options?: LangChainFileLoaderOptions) {
+    super(path, new PDFLoader(path), options);
   }
 }

--- a/typescript/src/ingestion/data-sources/fs/txtFileLoader.ts
+++ b/typescript/src/ingestion/data-sources/fs/txtFileLoader.ts
@@ -1,8 +1,11 @@
 import { TextLoader } from "langchain/document_loaders/fs/text";
-import { LangChainFileLoader } from "./langchainFileLoader";
+import {
+  LangChainFileLoader,
+  LangChainFileLoaderOptions,
+} from "./langchainFileLoader";
 
 export class TxtFileLoader extends LangChainFileLoader {
-  constructor(path: string) {
-    super(path, new TextLoader(path));
+  constructor(path: string, options?: LangChainFileLoaderOptions) {
+    super(path, new TextLoader(path), options);
   }
 }

--- a/typescript/src/ingestion/document-parsers/directDocumentParser.ts
+++ b/typescript/src/ingestion/document-parsers/directDocumentParser.ts
@@ -1,25 +1,20 @@
-import { JSONObject } from "../../common/jsonTypes";
 import {
   RawDocument,
   IngestedDocument,
   DocumentFragment,
 } from "../../document/document";
-import { BaseDocumentParser } from "./documentParser";
+import { BaseDocumentParser, DocumentParserConfig } from "./documentParser";
 import { v4 as uuid } from "uuid";
 import { Md5 } from "ts-md5";
-import { CallbackManager, ParseSuccessEvent } from "../../utils/callbacks";
+import { ParseSuccessEvent } from "../../utils/callbacks";
 
 /**
  * Parse a RawDocument directly into a Document, with each DocumentFragment
  * representing a RawDocumentChunk.
  */
 export class DirectDocumentParser extends BaseDocumentParser {
-  constructor(
-    attributes?: JSONObject,
-    metadata?: JSONObject,
-    callbackManager?: CallbackManager
-  ) {
-    super(attributes, metadata, callbackManager);
+  constructor(config?: DocumentParserConfig) {
+    super(config);
   }
 
   async parse(rawDocument: RawDocument): Promise<IngestedDocument> {

--- a/typescript/src/ingestion/document-parsers/documentParser.ts
+++ b/typescript/src/ingestion/document-parsers/documentParser.ts
@@ -1,5 +1,4 @@
 import { Attributable } from "../../common/base";
-import { JSONObject } from "../../common/jsonTypes";
 import {
   RawDocument,
   DocumentFragment,
@@ -40,19 +39,17 @@ export interface DocumentParser extends Attributable, Traceable {
   serialize(rawDocument: RawDocument): Promise<string>;
 }
 
+export interface DocumentParserConfig extends Attributable, Traceable {}
+
 export abstract class BaseDocumentParser implements DocumentParser {
   attributes = {};
   metadata = {};
   callbackManager?: CallbackManager;
 
-  constructor(
-    attributes?: JSONObject,
-    metadata?: JSONObject,
-    callbackManager?: CallbackManager
-  ) {
-    this.attributes = attributes ?? this.attributes;
-    this.metadata = metadata ?? this.metadata;
-    this.callbackManager = callbackManager;
+  constructor(config?: DocumentParserConfig) {
+    this.attributes = config?.attributes ?? this.attributes;
+    this.metadata = config?.metadata ?? this.metadata;
+    this.callbackManager = config?.callbackManager;
   }
 
   abstract parse(rawDocument: RawDocument): Promise<IngestedDocument>;

--- a/typescript/src/ingestion/document-parsers/multiDocumentParser.ts
+++ b/typescript/src/ingestion/document-parsers/multiDocumentParser.ts
@@ -1,12 +1,14 @@
 import { DocumentAccessPolicyFactory } from "../../access-control/documentAccessPolicyFactory";
 import { IngestedDocument, RawDocument } from "../../document/document";
 import { DocumentMetadataDB } from "../../document/metadata/documentMetadataDB";
+import { CallbackManager } from "../../utils/callbacks";
 import { ParserRegistry } from "./parserRegistry";
 
 type ParserConfig = {
   metadataDB?: DocumentMetadataDB;
   accessControlPolicyFactory?: DocumentAccessPolicyFactory;
   parserRegistry?: ParserRegistry;
+  callbackManager?: CallbackManager;
 };
 
 /**
@@ -22,7 +24,7 @@ export async function parseDocuments(
   rawDocuments: RawDocument[],
   config: ParserConfig
 ): Promise<IngestedDocument[]> {
-  const parserRegistry = config.parserRegistry ?? new ParserRegistry();
+  const parserRegistry = config.parserRegistry ?? new ParserRegistry(config);
 
   // Sanity check all parsers are available
   for (const rawDoc of rawDocuments) {

--- a/typescript/src/ingestion/document-parsers/parserRegistry.ts
+++ b/typescript/src/ingestion/document-parsers/parserRegistry.ts
@@ -1,5 +1,10 @@
 import { DirectDocumentParser } from "./directDocumentParser";
-import { DocumentParser } from "./documentParser";
+import { DocumentParser, DocumentParserConfig } from "./documentParser";
+
+export interface ParserRegistryConfig extends DocumentParserConfig {
+  defaultParser?: DocumentParser | null;
+  parsers?: Map<string, DocumentParser>;
+}
 
 /**
  * A registry of document parsers, keyed by MIME type. By default, DirectDocumentParser
@@ -11,20 +16,18 @@ export class ParserRegistry {
   defaultParser: DocumentParser | undefined;
   parsers: Map<string, DocumentParser>;
 
-  constructor(
-    parsers?: Map<string, DocumentParser>,
-    defaultParser?: DocumentParser | null
-  ) {
+  constructor(config: ParserRegistryConfig) {
     this.parsers =
-      parsers ??
+      config.parsers ??
       new Map([
-        // ["text/plain", new TextDocumentParser()],
-        // ['text/html', new HtmlDocumentParser()],
-        // ['application/pdf', new PDFDocumentParser()],
+        // ["text/plain", new TextDocumentParser(config)],
+        // ['text/html', new HtmlDocumentParser(config)],
+        // ['application/pdf', new PDFDocumentParser(config)],
       ]);
 
-    if (defaultParser !== null) {
-      this.defaultParser = defaultParser ?? new DirectDocumentParser();
+    if (config.defaultParser !== null) {
+      this.defaultParser =
+        config.defaultParser ?? new DirectDocumentParser(config);
     }
   }
 

--- a/typescript/src/ingestion/document-parsers/textDocumentParser.ts
+++ b/typescript/src/ingestion/document-parsers/textDocumentParser.ts
@@ -1,26 +1,16 @@
-import { JSONObject } from "../../common/jsonTypes";
 import {
   RawDocument,
   DocumentFragment,
   IngestedDocument,
 } from "../../document/document";
-import { CallbackManager } from "../../utils/callbacks";
-import { BaseDocumentParser } from "./documentParser";
+import { BaseDocumentParser, DocumentParserConfig } from "./documentParser";
 
 /**
  * A basic DocumentParser implementation for text/plain documents.
  */
 export class TextDocumentParser extends BaseDocumentParser {
-  attributes = {};
-  metadata = {};
-  callbackManager?: CallbackManager;
-
-  constructor(
-    attributes?: JSONObject,
-    metadata?: JSONObject,
-    callbackManager?: CallbackManager
-  ) {
-    super(attributes, metadata, callbackManager);
+  constructor(config?: DocumentParserConfig) {
+    super(config);
   }
 
   // TODO: Actually implement this when we have txt files loaded from non-langchain-directory sources

--- a/typescript/src/transformation/document/documentTransformer.ts
+++ b/typescript/src/transformation/document/documentTransformer.ts
@@ -3,7 +3,7 @@ import { DocumentMetadataDB } from "../../document/metadata/documentMetadataDB";
 import {
   CallbackManager,
   Traceable,
-  TranformDocumentsEvent,
+  TransformDocumentsEvent,
 } from "../../utils/callbacks";
 import { Transformer } from "../transformer";
 
@@ -67,7 +67,7 @@ export abstract class BaseDocumentTransformer
 
     const transformedDocuments = (await Promise.all(transformPromises)).flat();
 
-    const event: TranformDocumentsEvent = {
+    const event: TransformDocumentsEvent = {
       name: "onTransformDocuments",
       transformedDocuments,
       originalDocuments: documents,


### PR DESCRIPTION
# CallbackManager For ingest_data

Adding callbacks to the ingest_data script for the example. This required a few fixes (passing through CM in places it was missed).

Ran ingest_data:
```
ryanholinshead@Ryans-MacBook-Pro typescript % npx ts-node examples/financial_report/ingest_data.ts
Starting ingestion...
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_AAPL.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_ADBE.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_AMZN.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_ABBV.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_AVGO.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_COST.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_V.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_GOOG.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_HD.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_CVX.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_JNJ.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_META.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_LLY.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MSFT.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_NVDA.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_PEP.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_PG.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_UNH.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_TSLA.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_XOM.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_BRK.B.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MA.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MRK.md via TextLoader
Loaded 1 chunks from /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_JPM.md via TextLoader
Successfully loaded 24 documents from FileSystem
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_AAPL.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_AMZN.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_ADBE.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_AVGO.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_ABBV.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2022_V.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_COST.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_GOOG.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_HD.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_CVX.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_JNJ.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_LLY.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_META.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_NVDA.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MSFT.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_PG.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_PEP.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_TSLA.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_XOM.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_UNH.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_BRK.B.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MA.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_MRK.md into 1 fragments
Parsed /Users/ryanholinshead/Projects/semantic-retrieval/examples/example_data/financial_report/10ks/2023_JPM.md into 1 fragments
Transformed document f8316d3f-e47d-4d90-a9f7-efd0731742aa to b0306761-9831-4815-914b-1cd1839e1f94
Transformed document aed54d18-695c-4f07-9cf0-6d560562a62f to 5ff9171b-6e1f-46cb-9d01-2ed6e72eb7d0
Transformed document 0dba1b6e-3ca2-41da-ad7c-e70eb957fc9b to 8f810d32-6fe2-46f1-a5d0-8da7263b05a5
Transformed document 2596eb55-e6fa-42d4-afa5-3cdf1f98e442 to d48b2940-f117-43b0-9823-e974ac4f7183
Transformed document 954d9aa3-925f-4bbc-a183-3e3773d0307a to 6f83ce32-6c39-4ad3-b5db-daeeb00dc225
Transformed document 89887be1-3ded-4775-9f10-b8ff5416d510 to 9382e8d9-5d01-4e73-bb75-65ff8df31103
Transformed document f54e213f-27f1-4052-898c-85dfd7551be4 to 1b5c24f0-8a51-416a-b788-0b9aa81ec1b3
Transformed document d99444bf-f0be-4b65-8845-14ca3dd376e1 to 95b86346-c29d-4260-b10b-c10bb1f41669
Transformed document 3e3ce2f4-6036-4c58-8cc7-3fa540a2d5a0 to 7d015197-38d0-45cc-830f-cefe1a37b479
Transformed document fd854c7e-c11b-4e70-9093-ca98484160c9 to 7243556f-f007-4d2f-96a0-f35ee53b507b
Transformed document de5a5305-c090-4a36-ac6e-efef3df64519 to 7410158a-5de5-4860-8ea0-bd5ce710a2c7
Transformed document 3dec4c98-9a6a-46b7-9b63-3d20a550b402 to 846cf5dc-4c31-48e2-94e5-e799870b84ae
Transformed document ea2b24a0-1848-4217-8929-4d65e28cbcae to 27a7725f-a08b-4477-a73e-c75c88059d6b
Transformed document 5ecf55f6-e28a-446c-ae73-a0e3ab0973f9 to 118441d2-a074-4cb0-8ae7-967bd4257c10
Transformed document 534500ac-dc7a-4da5-9f1f-a420d139d972 to 740b0fd5-5c89-4d97-8d60-ff36ab911e70
Transformed document 72b3bc27-28df-4844-85af-d6c294a3071c to 6724fea2-36d5-4d16-9dad-0dfc99f98044
Transformed document 0200b19c-79dd-4915-9c98-e9ed31774f20 to b506809b-6ead-4194-ae2e-f0db598bb3cc
Transformed document d7a1b489-65bc-46ce-a871-0666b5c95f12 to e7415db8-0eab-44c1-b448-dbbeda7aca97
Transformed document 1e8facec-9baf-4bd8-b505-798a4ec4e938 to 7596a6d2-14b4-4b28-8b75-19964569e7d7
Transformed document d4b8d072-9313-41bc-8546-90ace0480ceb to c50a22e8-602e-4538-8b63-9a5141da7a92
Transformed document d2969066-6373-4884-afa7-16f02b2f1b46 to 1998a35a-d0c8-44dd-b415-0712776a2f15
Transformed document 0d405752-37bb-4f77-bd19-5bbab4a6cb56 to 5fc8647f-af18-4f27-a6ae-82f727698b66
Transformed document b613f614-1fbc-49c8-a67f-5228680ee28a to 56efa3f7-cfdb-40b4-b24d-e497998a7e1d
Transformed document 17e3fa71-2746-4395-b804-ae35b1389632 to b3e067b3-c1f5-4561-bf3c-4f5178b3707a
Transformed 24 documents for ingestion
Persisted metadataDB to disk
NAMESPACE: 14ecd741-3464-477a-88be-841618012109
Ingestion complete
Done!
```
