### PR TITLE
Improve perf of embeddings creation and pinecone upsert

### DIFF
--- a/typescript/__tests__/data-store/vector-DBs/pineconeVectorDB.test.ts
+++ b/typescript/__tests__/data-store/vector-DBs/pineconeVectorDB.test.ts
@@ -178,8 +178,8 @@ describe("pineconeVectorDB addDocuments", () => {
   });
 
   test("upserts many vectors in correct batches", async () => {
-    // 3 documents of 400 fragments each will have 5 parallel requests of 80
-    // vectors each, per document
+    // 3 documents of 400 fragments each will have 12 parallel requests of 100
+    // vectors each
     const testDocuments = Array(3).fill(
       getTestDocument({
         fragments: Array(400).fill(getTestDocumentFragment()),
@@ -187,7 +187,7 @@ describe("pineconeVectorDB addDocuments", () => {
     );
 
     await PineconeVectorDB.fromDocuments(testDocuments, TEST_CONFIG);
-    expect(mockUpsert).toHaveBeenCalledTimes(15);
+    expect(mockUpsert).toHaveBeenCalledTimes(12);
   });
 });
 

--- a/typescript/examples/financial_report/ingest_data.ts
+++ b/typescript/examples/financial_report/ingest_data.ts
@@ -95,7 +95,7 @@ async function main() {
 
   await vectorDB.addDocuments(transformedDocuments);
 
-  console.log("Ingestion complete");
+  console.log(`Ingestion to namespace ${namespace} complete!}`);
 }
 
 function getLoggingCallbackManager(verboseLogging: boolean) {


### PR DESCRIPTION
# Improve perf of embeddings creation and pinecone upsert

Let's be less conservative and default to some larger batch / request sizes, while supporting configuration of these sizes via config. This reduces ingestion of the 10ks from 10 minuts to ~5
