### PR TITLE
Callback Updates

### DIFF
--- a/typescript/__tests__/__mocks__/retrieval/testVectorDB.ts
+++ b/typescript/__tests__/__mocks__/retrieval/testVectorDB.ts
@@ -39,8 +39,7 @@ export default class TestVectorDB extends VectorDB {
       documents: _documents,
     };
 
-    // Open Q: Should this be await'ed
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
   }
 
   async query(_query: VectorDBQuery): Promise<VectorEmbedding[]> {
@@ -53,8 +52,7 @@ export default class TestVectorDB extends VectorDB {
       vectorEmbeddings,
     };
 
-    // Open Q: Should this be await'ed
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return vectorEmbeddings;
   }

--- a/typescript/examples/financial_report/components/financialReportDocumentRetriever.ts
+++ b/typescript/examples/financial_report/components/financialReportDocumentRetriever.ts
@@ -131,6 +131,7 @@ export class FinancialReportDocumentRetriever
 
     const event: RetrieveDataEvent = {
       name: "onRetrieveData",
+      params,
       data,
     };
 

--- a/typescript/examples/financial_report/generate_report.ts
+++ b/typescript/examples/financial_report/generate_report.ts
@@ -25,6 +25,7 @@ import { SecretReportAccessPolicy } from "./components/access_control/secretRepo
 import { AccessIdentity } from "../../../typescript/src/access-control/accessIdentity";
 import {
   CallbackManager,
+  QueryVectorDBEvent,
   RetrieveDataEvent,
   RetrievedFragmentPolicyCheckFailedEvent,
   RunCompletionGenerationEvent,
@@ -118,6 +119,7 @@ async function main() {
     namespace,
     embeddings: new OpenAIEmbeddings(),
     metadataDB,
+    callbackManager,
   });
 
   const documentRetriever = new VectorDBDocumentRetriever({
@@ -204,6 +206,20 @@ function getLoggingCallbackManager(verboseLogging: boolean) {
           documentId: event.fragment.documentId,
           policy: event.policy?.policy ?? "No policy specified",
         });
+      },
+    ],
+    onQueryVectorDB: [
+      async (event: QueryVectorDBEvent) => {
+        if (verboseLogging) {
+          console.log(
+            "Vector DB query and embeddings: ",
+            event.query,
+            event.vectorEmbeddings
+          );
+        }
+        console.log(
+          `VectorDB query returned ${event.vectorEmbeddings.length} embeddings`
+        );
       },
     ],
   });

--- a/typescript/src/data-store/vector-DBs/pineconeVectorDB.ts
+++ b/typescript/src/data-store/vector-DBs/pineconeVectorDB.ts
@@ -187,7 +187,7 @@ export class PineconeVectorDB extends VectorDB {
       name: "onAddDocumentsToVectorDB",
       documents,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
   }
 
   async query(query: VectorDBQuery): Promise<VectorEmbedding[]> {
@@ -230,7 +230,7 @@ export class PineconeVectorDB extends VectorDB {
       query: query,
       vectorEmbeddings: vectorEmbeddings,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return vectorEmbeddings;
   }

--- a/typescript/src/ingestion/document-parsers/directDocumentParser.ts
+++ b/typescript/src/ingestion/document-parsers/directDocumentParser.ts
@@ -57,7 +57,7 @@ export class DirectDocumentParser extends BaseDocumentParser {
       name: "onParseSuccess",
       ingestedDocument: out,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
     return out;
   }
 

--- a/typescript/src/retrieval/documentRetriever.ts
+++ b/typescript/src/retrieval/documentRetriever.ts
@@ -182,7 +182,7 @@ export abstract class DocumentRetriever<R = unknown> extends BaseRetriever {
       name: "onRetrieverGetDocumentsForFragments",
       documents,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return documents;
   }
@@ -216,9 +216,10 @@ export abstract class DocumentRetriever<R = unknown> extends BaseRetriever {
 
     const event: RetrieveDataEvent = {
       name: "onRetrieveData",
+      params,
       data: processedDocuments,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return processedDocuments;
   }

--- a/typescript/src/retrieval/vector-DBs/vectorDBDocumentRetriever.ts
+++ b/typescript/src/retrieval/vector-DBs/vectorDBDocumentRetriever.ts
@@ -20,7 +20,7 @@ export class VectorDBDocumentRetriever extends BaseVectorDBRetriever<
       name: "onRetrieverProcessDocuments",
       documents,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return documents;
   }

--- a/typescript/src/retrieval/vector-DBs/vectorDBRetriever.ts
+++ b/typescript/src/retrieval/vector-DBs/vectorDBRetriever.ts
@@ -73,7 +73,7 @@ export abstract class BaseVectorDBRetriever<
       name: "onGetFragments",
       fragments: documentFragments,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return documentFragments;
   }
@@ -108,9 +108,10 @@ export abstract class BaseVectorDBRetriever<
 
     const event: RetrieveDataEvent = {
       name: "onRetrieveData",
+      params,
       data: processedDocuments,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return processedDocuments;
   }

--- a/typescript/src/transformation/document/documentTransformer.ts
+++ b/typescript/src/transformation/document/documentTransformer.ts
@@ -72,7 +72,7 @@ export abstract class BaseDocumentTransformer
       transformedDocuments,
       originalDocuments: documents,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return transformedDocuments;
   }

--- a/typescript/src/transformation/document/text/separatorTextChunker.ts
+++ b/typescript/src/transformation/document/text/separatorTextChunker.ts
@@ -40,7 +40,7 @@ export class SeparatorTextChunker extends TextChunkTransformer {
       name: "onChunkText",
       chunks: mergedChunks,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     return mergedChunks;
   }

--- a/typescript/src/transformation/document/text/textChunkTransformer.ts
+++ b/typescript/src/transformation/document/text/textChunkTransformer.ts
@@ -113,7 +113,7 @@ export abstract class TextChunkTransformer
       originalDocument: document,
       transformedDocument,
     };
-    this.callbackManager?.runCallbacks(event);
+    await this.callbackManager?.runCallbacks(event);
 
     // TODO: Think through metadata handling, since setting new doc metadata on each transformation
     // can cause proliferation of DB entries. On the other hand, we probably don't want to mutate

--- a/typescript/src/utils/callbacks.ts
+++ b/typescript/src/utils/callbacks.ts
@@ -14,6 +14,7 @@ import type {
 import { CompletionModelParams } from "../generator/completion-models/completionModel";
 import { VectorEmbedding } from "../transformation/embeddings/embeddings";
 import { DataSource } from "../ingestion/data-sources/dataSource";
+import { BaseRetrieverQueryParams } from "../retrieval/retriever";
 
 export type LoadDocumentsSuccessEvent = {
   name: "onLoadDocumentsSuccess";
@@ -122,6 +123,7 @@ export type RetrieverProcessDocumentsEvent = {
 
 export type RetrieveDataEvent = {
   name: "onRetrieveData";
+  params: BaseRetrieverQueryParams;
   data: any;
 };
 


### PR DESCRIPTION
Callback Updates

# Callback Updates
- Use await before callbackManager.runCallbacks calls where possible
- Add params to retrieve data callback for extra info

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/183).
* #190
* #188
* #184
* __->__ #183