### PR TITLE
Remove cchardet as dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,6 @@ openai==0.28.1
 python-dotenv
 pytest-asyncio
 pyright
-cchardet
 pandas
 chardet
 scikit-learn


### PR DESCRIPTION
Remove cchardet as dependency

Test plan:

Removed old conda env, created new one, installed deps & installed library in environment then checked import worked in interpreter
```
rm -rf /opt/homebrew/Caskroom/miniconda/base/envs/semantic_retrieval
conda env create -f environment.yml
conda activate semantic_retrieval
pip install -e .
python
```

```
import semantic_retrieval
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/185).
* #187
* __->__ #185