### PR TITLE
Update aiconfig code to use new load api

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,6 @@ openai==0.28.1
 python-dotenv
 pytest-asyncio
 pyright
-cchardet
 pandas
 chardet
 scikit-learn

--- a/python/src/semantic_retrieval/generator/retrieval_augmented_generation/generator.py
+++ b/python/src/semantic_retrieval/generator/retrieval_augmented_generation/generator.py
@@ -5,7 +5,7 @@ from aiconfig.model_parser import InferenceOptions
 
 
 async def generate(ai_config_path: str, params: Dict[str, str]) -> str:
-    runtime = AIConfigRuntime.from_config(ai_config_path)
+    runtime = AIConfigRuntime.load(ai_config_path)
 
     def callback(data: Any, acc: Any, output_num: int) -> None:
         if "content" in data:
@@ -26,11 +26,11 @@ async def generate(ai_config_path: str, params: Dict[str, str]) -> str:
 
 
 async def resolve_ai_config(ai_config_path: str, params: Dict[str, str]) -> Any:
-    runtime = AIConfigRuntime.from_config(ai_config_path)
+    runtime = AIConfigRuntime.load(ai_config_path)
     return await runtime.resolve("rag_complete", params=params)
 
 
 def ai_config_metadata_lookup(ai_config_path: str, key: str) -> Dict[str, str]:
-    runtime = AIConfigRuntime.from_config(ai_config_path)
+    runtime = AIConfigRuntime.load(ai_config_path)
     md = getattr(runtime.metadata, key)
     return md


### PR DESCRIPTION
Update aiconfig code to use new load api

1.0.4 -> 1.0.5 migration

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/186).
* #187
* __->__ #186
* #185