### PR TITLE
Exclude unnecessary files from compilation

### DIFF
--- a/typescript/tsconfig.build.json
+++ b/typescript/tsconfig.build.json
@@ -18,7 +18,5 @@
     // to avoid that.
     "skipLibCheck": true,
   },
-  "exclude": [
-    "__tests__"
-  ]
+  "exclude": ["__tests__", "examples", "dist", "node_modules"]
 }

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -21,5 +21,5 @@
   // See https://stackoverflow.com/a/61107618 for more info
   "include": ["src", "__tests__"],
   "types": ["jest"],
-  "exclude": ["dist", "docs", "examples", "node_modules"]
+  "exclude": ["dist", "examples", "node_modules"]
 }


### PR DESCRIPTION
# Exclude unnecessary files from compilation

The override in the build config was missing some folders to exclude, so add them to the excludes list

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/semantic-retrieval/pull/191).
* #192
* __->__ #191