### PR TITLE
Final package update to include only dist, README, and package.json in published package

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -20,6 +20,9 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand",


### PR DESCRIPTION
Final package update to include only dist, README, and package.json in published package

`npm publish --dry-run` has dist, README and package.json. No node_modules, etc.
